### PR TITLE
Fixed a typescript definition to match source.

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3665,7 +3665,7 @@ declare module Phaser {
             static VERSION: string;
             static COST_ORTHOGONAL: number;
             static COST_DIAGONAL: number;
-            static DISTANCE_MANHATTEN: string;
+            static DISTANCE_MANHATTAN: string;
             static DISTANCE_EUCLIDIAN: string;
 
             constructor(parent: PIXI.DisplayObject);


### PR DESCRIPTION
Phaser.d.ts fix for Phaser.Plugin.AStar.DISTANCE_MANHATTAN (was DISTANCE_MANHATTEN) to match https://github.com/photonstorm/phaser-plugins/blob/master/AStar/AStar.js

** >> Make sure you describe your PR in the README Change Log section! << **

This PR changes (delete as applicable)

* TypeScript Defs

Describe the changes below:

Oops, I missed the DISTANCE_MANHATTEN :)

Too bad this PR didn't quite make it to 2.7.3 (with the COST_ORTHAGONAL and COST_DIAGAONAL fix) but better late than never I guess.