### PR TITLE
Update Loader.js

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2345,7 +2345,9 @@ Phaser.Loader.prototype = {
         file.data.src = this.transformUrl(file.url, file);
 
         // Image is immediately-available/cached
-        if (file.data.complete && file.data.width && file.data.height)
+        // Special Firefox magic, exclude from cached reload
+        // More info here: https://github.com/photonstorm/phaser/issues/2534
+        if (!this.game.device.firefox && file.data.complete && file.data.width && file.data.height)
         {
             file.data.onload = null;
             file.data.onerror = null;


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:
* Changed Loader.loadImageTag behavior to exclude firefox from loading cached images (#2534)
