### PR TITLE
Implemented TilemapLayer offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added yarn lock file
 * Added travis-ci build script
 * Added copyBitmapData function to Phaser.Bitmap.
+* Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics.
 
 ## Version 2.7.3 - 9th January 2017
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Added yarn lock file
 * Added travis-ci build script
 * Added copyBitmapData function to Phaser.Bitmap.
-* Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics.
+* Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics. Also, these properties are now read from the `offsetx` and `offsety` layer properties of Tiled maps.
 
 ## Version 2.7.3 - 9th January 2017
 

--- a/src/physics/arcade/TilemapCollision.js
+++ b/src/physics/arcade/TilemapCollision.js
@@ -39,8 +39,8 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
         }
 
         var mapData = tilemapLayer.getTiles(
-            sprite.body.position.x - sprite.body.tilePadding.x,
-            sprite.body.position.y - sprite.body.tilePadding.y,
+            sprite.body.position.x - sprite.body.tilePadding.x - tilemapLayer.getLayerOffsetX(),
+            sprite.body.position.y - sprite.body.tilePadding.y - tilemapLayer.getLayerOffsetY(),
             sprite.body.width + sprite.body.tilePadding.x,
             sprite.body.height + sprite.body.tilePadding.y,
             false, false);
@@ -129,8 +129,8 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
             return false;
         }
         
-        var tilemapLayerOffsetX = (!tilemapLayer.fixedToCamera) ? tilemapLayer.position.x : 0;
-        var tilemapLayerOffsetY = (!tilemapLayer.fixedToCamera) ? tilemapLayer.position.y : 0;
+        var tilemapLayerOffsetX = tilemapLayer.getLayerOffsetX();
+        var tilemapLayerOffsetY = tilemapLayer.getLayerOffsetY();
 
         //  We re-check for collision in case body was separated in a previous step
         if (!tile.intersects((body.position.x - tilemapLayerOffsetX), (body.position.y - tilemapLayerOffsetY), (body.right - tilemapLayerOffsetX), (body.bottom - tilemapLayerOffsetY)))

--- a/src/physics/arcade/TilemapCollision.js
+++ b/src/physics/arcade/TilemapCollision.js
@@ -242,7 +242,7 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
     tileCheckX: function (body, tile, tilemapLayer) {
 
         var ox = 0;
-        var tilemapLayerOffsetX = (!tilemapLayer.fixedToCamera) ? tilemapLayer.position.x : 0;
+        var tilemapLayerOffsetX = tilemapLayer.getLayerOffsetX();
 
         if (body.deltaX() < 0 && !body.blocked.left && tile.collideRight && body.checkCollision.left)
         {
@@ -300,7 +300,7 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
     tileCheckY: function (body, tile, tilemapLayer) {
 
         var oy = 0;
-        var tilemapLayerOffsetY = (!tilemapLayer.fixedToCamera) ? tilemapLayer.position.y : 0;
+        var tilemapLayerOffsetY = tilemapLayer.getLayerOffsetY();
 
         if (body.deltaY() < 0 && !body.blocked.up && tile.collideDown && body.checkCollision.up)
         {

--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -622,9 +622,6 @@ Phaser.Tilemap.prototype = {
 
         var rootLayer = group.add(new Phaser.TilemapLayer(this.game, this, index, width, height));
 
-        rootLayer.layerOffsetX = this.layers[index].offsetX;
-        rootLayer.layerOffsetY = this.layers[index].offsetY;
-
         if (this.enableDebug)
         {
             console.groupEnd();

--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -622,6 +622,9 @@ Phaser.Tilemap.prototype = {
 
         var rootLayer = group.add(new Phaser.TilemapLayer(this.game, this, index, width, height));
 
+        rootLayer.layerOffsetX = this.layers[index].offsetX;
+        rootLayer.layerOffsetY = this.layers[index].offsetY;
+
         if (this.enableDebug)
         {
             console.groupEnd();

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -216,10 +216,22 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
 
     /**
     * The current canvas top after scroll is applied.
-    * @propety {number} _scrollY
+    * @property {number} _scrollY
     * @private
     */
     this._scrollY = 0;
+
+    /**
+     * The X axis position offset of the layer.
+     * @property {Number}
+     */
+    this.layerOffsetX = 0;
+    
+    /**
+     * The Y axis position offset of the layer.
+     * @type {number}
+     */
+    this.layerOffsetY = 0;
 
     /**
     * Used for caching the tiles / array of tiles.
@@ -295,8 +307,8 @@ Phaser.TilemapLayer.prototype.postUpdate = function () {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
 
-    this._scrollX = this.game.camera.view.x * this.scrollFactorX / this.scale.x;
-    this._scrollY = this.game.camera.view.y * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
 
 };
 
@@ -315,8 +327,8 @@ Phaser.TilemapLayer.prototype._renderCanvas = function (renderSession) {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
 
-    this._scrollX = this.game.camera.view.x * this.scrollFactorX / this.scale.x;
-    this._scrollY = this.game.camera.view.y * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
 
     this.render();
 
@@ -339,8 +351,8 @@ Phaser.TilemapLayer.prototype._renderWebGL = function (renderSession) {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
     
-    this._scrollX = this.game.camera.view.x * this.scrollFactorX / this.scale.x;
-    this._scrollY = this.game.camera.view.y * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
 
     this.render();
 
@@ -409,6 +421,26 @@ Phaser.TilemapLayer.prototype.resizeWorld = function () {
 
     this.game.world.setBounds(0, 0, this.layer.widthInPixels * this.scale.x, this.layer.heightInPixels * this.scale.y);
 
+};
+
+/**
+ * Get the X axis position offset of this layer.
+ *
+ * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @return {number}
+ */
+Phaser.TilemapLayer.prototype.getLayerOffsetX = function () {
+	return this.layerOffsetX;
+};
+
+/**
+ * Get the Y axis position offset of this layer.
+ *
+ * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @return {number}
+ */
+Phaser.TilemapLayer.prototype.getLayerOffsetY = function () {
+	return this.layerOffsetY;
 };
 
 /**

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -223,10 +223,10 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
 
     /**
      * The X axis position offset of the layer.
-     * @property {Number}
+     * @property {number}
      */
     this.layerOffsetX = 0;
-    
+
     /**
      * The Y axis position offset of the layer.
      * @type {number}
@@ -427,20 +427,26 @@ Phaser.TilemapLayer.prototype.resizeWorld = function () {
  * Get the X axis position offset of this layer.
  *
  * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @public
  * @return {number}
  */
 Phaser.TilemapLayer.prototype.getLayerOffsetX = function () {
-	return this.layerOffsetX;
+
+    return this.layerOffsetX;
+
 };
 
 /**
  * Get the Y axis position offset of this layer.
  *
  * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @public
  * @return {number}
  */
 Phaser.TilemapLayer.prototype.getLayerOffsetY = function () {
-	return this.layerOffsetY;
+
+    return this.layerOffsetY;
+
 };
 
 /**

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -432,7 +432,7 @@ Phaser.TilemapLayer.prototype.resizeWorld = function () {
  */
 Phaser.TilemapLayer.prototype.getLayerOffsetX = function () {
 
-    return this.layerOffsetX;
+    return this.layerOffsetX || ((!this.fixedToCamera) ? this.position.x : 0);
 
 };
 
@@ -445,7 +445,7 @@ Phaser.TilemapLayer.prototype.getLayerOffsetX = function () {
  */
 Phaser.TilemapLayer.prototype.getLayerOffsetY = function () {
 
-    return this.layerOffsetY;
+    return this.layerOffsetY || ((!this.fixedToCamera) ? this.position.y : 0);
 
 };
 

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -225,13 +225,13 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
      * The X axis position offset of the layer.
      * @property {number}
      */
-    this.layerOffsetX = 0;
+    this.layerOffsetX = this.layer.offsetX || 0;
 
     /**
      * The Y axis position offset of the layer.
      * @type {number}
      */
-    this.layerOffsetY = 0;
+    this.layerOffsetY = this.layer.offsetY || 0;
 
     /**
     * Used for caching the tiles / array of tiles.

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -258,6 +258,8 @@ Phaser.TilemapParser = {
                 widthInPixels: curl.width * json.tilewidth,
                 heightInPixels: curl.height * json.tileheight,
                 alpha: curl.opacity,
+                offsetX: curl.offsetx,
+                offsetY: curl.offsety,
                 visible: curl.visible,
                 properties: {},
                 indexes: [],


### PR DESCRIPTION
This PR changes **the public-facing API**.

It implements offsetting tilemap layer positions in a way that plays well with the camera and Arcade physics.

It includes support for the Tiled map `offsetx` and `offsety` layer properties.