### PR TITLE
Fix to get grunt tsdocs work again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Added travis-ci build script
 * Added copyBitmapData function to Phaser.Bitmap.
 * Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics. Also, these properties are now read from the `offsetx` and `offsety` layer properties of Tiled maps.
+* Fixed Phaser.Plugin.AStar Typescript definitions to get `grunt tsdocs` to work again
 
 ## Version 2.7.3 - 9th January 2017
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4,7 +4,7 @@
 // Type definitions for Phaser CE
 // Project: https://github.com/photonstorm/phaser-ce
 
-declare module "phaser" {
+declare module "phaser-ce" {
     export = Phaser;
 }
 
@@ -3696,11 +3696,16 @@ declare module Phaser {
 
             }
 
+            interface AStarNodeArray {
+                x: number;
+                y: number;
+            }
+
             class AStarPath {
 
-                constructor(nodes?: {x: number, y: number}[], start?: Phaser.Plugin.AStar.AStarNode, goal?: Phaser.Plugin.AStar.AStarNode);
+                constructor(nodes?: AStarNodeArray[], start?: Phaser.Plugin.AStar.AStarNode, goal?: Phaser.Plugin.AStar.AStarNode);
 
-                nodes: {x: number, y: number}[];
+                nodes: AStarNodeArray[];
                 start: Phaser.Plugin.AStar.AStarNode;
                 goal: Phaser.Plugin.AStar.AStarNode;
                 visited: Phaser.Plugin.AStar.AStarNode[];


### PR DESCRIPTION
This PR changes (delete as applicable)

* TypeScript Defs

Describe the changes below:

- Fixed module name for phaser-ce
- Fixed AStar plugin definition to get grunt tsdocs work again, which currently breaks with an error

Fixes: #29 