### PR TITLE
Refactored layerOffsetX and layerOffsetY properties to tileOffset property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Added yarn lock file
 * Added travis-ci build script
 * Added copyBitmapData function to Phaser.Bitmap.
-* Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics. Also, these properties are now read from the `offsetx` and `offsety` layer properties of Tiled maps.
+* Added `tileOffset` (`Phaser.Point`) property to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics. Also, the `offsetx` and `offsety` properties are now read from the layer properties of Tiled maps.
 * Fixed Phaser.Plugin.AStar Typescript definitions to get `grunt tsdocs` to work again
 
 ## Version 2.7.3 - 9th January 2017

--- a/src/physics/arcade/TilemapCollision.js
+++ b/src/physics/arcade/TilemapCollision.js
@@ -39,8 +39,8 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
         }
 
         var mapData = tilemapLayer.getTiles(
-            sprite.body.position.x - sprite.body.tilePadding.x - tilemapLayer.getLayerOffsetX(),
-            sprite.body.position.y - sprite.body.tilePadding.y - tilemapLayer.getLayerOffsetY(),
+            sprite.body.position.x - sprite.body.tilePadding.x - tilemapLayer.getTileOffsetX(),
+            sprite.body.position.y - sprite.body.tilePadding.y - tilemapLayer.getTileOffsetY(),
             sprite.body.width + sprite.body.tilePadding.x,
             sprite.body.height + sprite.body.tilePadding.y,
             false, false);
@@ -129,8 +129,8 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
             return false;
         }
         
-        var tilemapLayerOffsetX = tilemapLayer.getLayerOffsetX();
-        var tilemapLayerOffsetY = tilemapLayer.getLayerOffsetY();
+        var tilemapLayerOffsetX = tilemapLayer.getTileOffsetX();
+        var tilemapLayerOffsetY = tilemapLayer.getTileOffsetY();
 
         //  We re-check for collision in case body was separated in a previous step
         if (!tile.intersects((body.position.x - tilemapLayerOffsetX), (body.position.y - tilemapLayerOffsetY), (body.right - tilemapLayerOffsetX), (body.bottom - tilemapLayerOffsetY)))
@@ -242,7 +242,7 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
     tileCheckX: function (body, tile, tilemapLayer) {
 
         var ox = 0;
-        var tilemapLayerOffsetX = tilemapLayer.getLayerOffsetX();
+        var tilemapLayerOffsetX = tilemapLayer.getTileOffsetX();
 
         if (body.deltaX() < 0 && !body.blocked.left && tile.collideRight && body.checkCollision.left)
         {
@@ -300,7 +300,7 @@ Phaser.Physics.Arcade.TilemapCollision.prototype = {
     tileCheckY: function (body, tile, tilemapLayer) {
 
         var oy = 0;
-        var tilemapLayerOffsetY = tilemapLayer.getLayerOffsetY();
+        var tilemapLayerOffsetY = tilemapLayer.getTileOffsetY();
 
         if (body.deltaY() < 0 && !body.blocked.up && tile.collideDown && body.checkCollision.up)
         {

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -223,7 +223,7 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
 
     /**
      * The position offset of the layer's tiles.
-     * @property {number}
+     * @property {Phaser.Point}
      */
     this.tileOffset = new Phaser.Point(this.layer.offsetX || 0, this.layer.offsetY || 0);
 

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -222,16 +222,10 @@ Phaser.TilemapLayer = function (game, tilemap, index, width, height) {
     this._scrollY = 0;
 
     /**
-     * The X axis position offset of the layer.
+     * The position offset of the layer's tiles.
      * @property {number}
      */
-    this.layerOffsetX = this.layer.offsetX || 0;
-
-    /**
-     * The Y axis position offset of the layer.
-     * @type {number}
-     */
-    this.layerOffsetY = this.layer.offsetY || 0;
+    this.tileOffset = new Phaser.Point(this.layer.offsetX || 0, this.layer.offsetY || 0);
 
     /**
     * Used for caching the tiles / array of tiles.
@@ -307,8 +301,8 @@ Phaser.TilemapLayer.prototype.postUpdate = function () {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
 
-    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
-    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.tileOffset.x) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.tileOffset.y) * this.scrollFactorY / this.scale.y;
 
 };
 
@@ -327,8 +321,8 @@ Phaser.TilemapLayer.prototype._renderCanvas = function (renderSession) {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
 
-    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
-    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.tileOffset.x) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.tileOffset.y) * this.scrollFactorY / this.scale.y;
 
     this.render();
 
@@ -351,8 +345,8 @@ Phaser.TilemapLayer.prototype._renderWebGL = function (renderSession) {
         this.position.y = (this.game.camera.view.y + this.cameraOffset.y) / this.game.camera.scale.y;
     }
     
-    this._scrollX = (this.game.camera.view.x - this.layerOffsetX) * this.scrollFactorX / this.scale.x;
-    this._scrollY = (this.game.camera.view.y - this.layerOffsetY) * this.scrollFactorY / this.scale.y;
+    this._scrollX = (this.game.camera.view.x - this.tileOffset.x) * this.scrollFactorX / this.scale.x;
+    this._scrollY = (this.game.camera.view.y - this.tileOffset.y) * this.scrollFactorY / this.scale.y;
 
     this.render();
 
@@ -424,28 +418,28 @@ Phaser.TilemapLayer.prototype.resizeWorld = function () {
 };
 
 /**
- * Get the X axis position offset of this layer.
+ * Get the X axis position offset of this layer's tiles.
  *
- * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @method Phaser.TilemapLayer#getLayerOffsetX
  * @public
  * @return {number}
  */
-Phaser.TilemapLayer.prototype.getLayerOffsetX = function () {
+Phaser.TilemapLayer.prototype.getTileOffsetX = function () {
 
-    return this.layerOffsetX || ((!this.fixedToCamera) ? this.position.x : 0);
+    return this.tileOffset.x || ((!this.fixedToCamera) ? this.position.x : 0);
 
 };
 
 /**
- * Get the Y axis position offset of this layer.
+ * Get the Y axis position offset of this layer's tiles.
  *
- * @method Phaser.TilemapLayer#getLayerOffsetY
+ * @method Phaser.TilemapLayer#getTileOffsetY
  * @public
  * @return {number}
  */
-Phaser.TilemapLayer.prototype.getLayerOffsetY = function () {
+Phaser.TilemapLayer.prototype.getTileOffsetY = function () {
 
-    return this.layerOffsetY || ((!this.fixedToCamera) ? this.position.y : 0);
+    return this.tileOffset.y || ((!this.fixedToCamera) ? this.position.y : 0);
 
 };
 


### PR DESCRIPTION
This PR changes **the public-facing API**.

I decided to squeeze this renaming in now to avoid backwards compatible changes with later Phaser CE versions, as I'm working on [something](https://github.com/hexus/phaser-ce/commits/tilemap-scaling "Camera and tilemap scaling!") that may not be finished in time for 2.7.4.