### PR TITLE
Add loadPolygon() rescale functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Added copyBitmapData function to Phaser.Bitmap.
 * Added `layerOffsetX` and `layerOffsetY` properties to `Phaser.TilemapLayer`. This allows offsetting layer positions in a way that plays well with the camera and Arcade physics. Also, these properties are now read from the `offsetx` and `offsety` layer properties of Tiled maps.
 * Fixed Phaser.Plugin.AStar Typescript definitions to get `grunt tsdocs` to work again
+* Added Phaser.Physics.P2.Body.loadPolygon() functionality that allows the loaded polygon to have a different scale.
 
 ## Version 2.7.3 - 9th January 2017
 

--- a/src/physics/p2/Body.js
+++ b/src/physics/p2/Body.js
@@ -1434,7 +1434,7 @@ Phaser.Physics.P2.Body.prototype = {
     *     or if key is null pass the actual physics data object itself as this parameter.
     * @return {boolean} True on success, else false.
     */
-    loadPolygon: function (key, object) {
+    loadPolygon: function (key, object, scale) {
 
         if (key === null)
         {
@@ -1443,6 +1443,11 @@ Phaser.Physics.P2.Body.prototype = {
         else
         {
             var data = this.game.cache.getPhysicsData(key, object);
+        }
+        
+        if (typeof scale !== "number")
+        {
+            scale = 1;
         }
 
         //  We've multiple Convex shapes, they should be CCW automatically
@@ -1454,7 +1459,10 @@ Phaser.Physics.P2.Body.prototype = {
 
             for (var s = 0; s < data[i].shape.length; s += 2)
             {
-                vertices.push([ this.world.pxmi(data[i].shape[s]), this.world.pxmi(data[i].shape[s + 1]) ]);
+                vertices.push([
+                    this.world.pxmi(data[i].shape[s] * scale),
+                    this.world.pxmi(data[i].shape[s + 1] * scale)
+                ]);
             }
 
             var c = new p2.Convex({ vertices: vertices });


### PR DESCRIPTION
This PR changes
* The public-facing API

Description:
Allows the loaded polygon through `loadPolygon()` to be rescaled. If you plan on using different sized Sprites, you would probably want to use different sized bodies. The scale can't be changed later, but that wouldn't matter if the Sprite using this polygon has a constant scale. I've used this reworked method for a while and it has been working perfectly so far, even with negative numbers.