### PR TITLE
missing definition in phaser.d.ts

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -1795,6 +1795,7 @@ declare module Phaser {
         forEachDead(callback: Function, callbackContext?: any, ...args: any[]): void;
         forEachExists(callback: Function, callbackContext?: any): void;
         filter(predicate: Function, checkExists?: boolean): ArraySet;
+        getAll(property: string, value: any, startIndex: number, endIndex: number): any;
         getAt(index: number): PIXI.DisplayObject | number;
         getBottom(): any;
         getByName(name: string): any;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1795,6 +1795,7 @@ declare module Phaser {
         forEachDead(callback: Function, callbackContext?: any, ...args: any[]): void;
         forEachExists(callback: Function, callbackContext?: any): void;
         filter(predicate: Function, checkExists?: boolean): ArraySet;
+        getAll(property: string, value: any, startIndex: number, endIndex: number): any;
         getAt(index: number): PIXI.DisplayObject | number;
         getBottom(): any;
         getByName(name: string): any;


### PR DESCRIPTION
This PR changes: TypeScript Defs

Describe the changes below:
added missing method definition for Phaser.Group.GetAll()

