### PR TITLE
update Text.setStyle to not mutate the passed style

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -312,56 +312,56 @@ Phaser.Text.prototype.setStyle = function (style, update) {
 
     if (update === undefined) { update = false; }
 
-    style = style || {};
-    style.font = style.font || 'bold 20pt Arial';
-    style.backgroundColor = style.backgroundColor || null;
-    style.fill = style.fill || 'black';
-    style.align = style.align || 'left';
-    style.boundsAlignH = style.boundsAlignH || 'left';
-    style.boundsAlignV = style.boundsAlignV || 'top';
-    style.stroke = style.stroke || 'black'; //provide a default, see: https://github.com/GoodBoyDigital/pixi.js/issues/136
-    style.strokeThickness = style.strokeThickness || 0;
-    style.wordWrap = style.wordWrap || false;
-    style.wordWrapWidth = style.wordWrapWidth || 100;
-    style.maxLines = style.maxLines || 0;
-    style.shadowOffsetX = style.shadowOffsetX || 0;
-    style.shadowOffsetY = style.shadowOffsetY || 0;
-    style.shadowColor = style.shadowColor || 'rgba(0,0,0,0)';
-    style.shadowBlur = style.shadowBlur || 0;
-    style.tabs = style.tabs || 0;
+    var newStyle = Object.assign({}, style);
+    newStyle.font = style.font || 'bold 20pt Arial';
+    newStyle.backgroundColor = style.backgroundColor || null;
+    newStyle.fill = style.fill || 'black';
+    newStyle.align = style.align || 'left';
+    newStyle.boundsAlignH = style.boundsAlignH || 'left';
+    newStyle.boundsAlignV = style.boundsAlignV || 'top';
+    newStyle.stroke = style.stroke || 'black'; //provide a default, see: https://github.com/GoodBoyDigital/pixi.js/issues/136
+    newStyle.strokeThickness = style.strokeThickness || 0;
+    newStyle.wordWrap = style.wordWrap || false;
+    newStyle.wordWrapWidth = style.wordWrapWidth || 100;
+    newStyle.maxLines = style.maxLines || 0;
+    newStyle.shadowOffsetX = style.shadowOffsetX || 0;
+    newStyle.shadowOffsetY = style.shadowOffsetY || 0;
+    newStyle.shadowColor = style.shadowColor || 'rgba(0,0,0,0)';
+    newStyle.shadowBlur = style.shadowBlur || 0;
+    newStyle.tabs = style.tabs || 0;
 
-    var components = this.fontToComponents(style.font);
+    var components = this.fontToComponents(newStyle.font);
 
-    if (style.fontStyle)
+    if (newStyle.fontStyle)
     {
-        components.fontStyle = style.fontStyle;
+        components.fontStyle = newStyle.fontStyle;
     }
 
-    if (style.fontVariant)
+    if (newStyle.fontVariant)
     {
-        components.fontVariant = style.fontVariant;
+        components.fontVariant = newStyle.fontVariant;
     }
 
-    if (style.fontWeight)
+    if (newStyle.fontWeight)
     {
-        components.fontWeight = style.fontWeight;
+        components.fontWeight = newStyle.fontWeight;
     }
 
-    if (style.fontSize)
+    if (newStyle.fontSize)
     {
-        if (typeof style.fontSize === 'number')
+        if (typeof newStyle.fontSize === 'number')
         {
-            style.fontSize = style.fontSize + 'px';
+            newStyle.fontSize = newStyle.fontSize + 'px';
         }
 
-        components.fontSize = style.fontSize;
+        components.fontSize = newStyle.fontSize;
     }
 
     this._fontComponents = components;
 
-    style.font = this.componentsToFont(this._fontComponents);
+    newStyle.font = this.componentsToFont(this._fontComponents);
 
-    this.style = style;
+    this.style = newStyle;
     this.dirty = true;
 
     if (update)


### PR DESCRIPTION
Instead a copy is kept

This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

setStyle is currently a mutator method that keeps a reference to the passed in style parameter. If the user modifies this style later, then the Text will be effected. Likewise, setting default params on this style means it cannot be reused between texts without being altered 