### PR TITLE
Fixed group updating if a sprite has been destroyed

### DIFF
--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -1648,6 +1648,7 @@ Phaser.Group.prototype.update = function () {
 
     while (i--)
     {
+        if (i >= this.children.length){i = this.children.length - 1}
         this.children[i].update();
     }
 


### PR DESCRIPTION
If a sprite is destroyed during another sprite's update function, the game will no longer crash.

