### PR TITLE
Fix duplicate touch events in Android Chrome >= 55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Fixed jshint issues
 * Added preUpdateLifeSpan for Image
 * Added missing parameter particleArguments at typescript definition file
+* Fixed duplicate touch events in Android Chrome >= 55 due to introduction of PointerEvents.
 
 
 ## Version 2.7.3 - 9th January 2017

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -422,7 +422,12 @@ Phaser.Input.prototype = {
         this.hitContext = this.hitCanvas.getContext('2d');
 
         this.mouse.start();
-        this.touch.start();
+        if (!this.game.device.mspointer)
+        {
+            // Chrome >= 55 fires both PointerEvent and TouchEvent.
+            // Pick only one.
+            this.touch.start();
+        }
         this.mspointer.start();
         this.mousePointer.active = true;
 


### PR DESCRIPTION
This PR changes (delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Chrome version 55 or above introduces PointerEvents, and emits both touch and pointer events when a touch is performed.
This code simply skips initialisation of touch event handlers (touch.start()) if Pointer events are available.

Fixes #32

Moving forward, it might be better to rename src/input/MSPointer.js to a more generic name, seeing that PointerEvent possibly gaining acceptance across major browsers.

