### PR TITLE
Fixes compatibility with older browsers.

### DIFF
--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -312,7 +312,7 @@ Phaser.Text.prototype.setStyle = function (style, update) {
 
     if (update === undefined) { update = false; }
 
-    var newStyle = Object.assign({}, style);
+    var newStyle = Phaser.Utils.extend({}, style);
     newStyle.font = style.font || 'bold 20pt Arial';
     newStyle.backgroundColor = style.backgroundColor || null;
     newStyle.fill = style.fill || 'black';


### PR DESCRIPTION
This PR changes (delete as applicable)
* Nothing, it's a bug fix

Describe the changes below:
Make Phaser.Text use Phaser.Util.extend() instead of Object.assign(), which an ES6-only feature .

Fixes #81
