### PR TITLE
Fixed Object.assign for older devices that don't support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,12 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 ![Change Log](http://phaser.io/images/github/div-change-log.png "Change Log")
 <a name="change-log"></a>
 
+## Version 2.7.6
+
+## Bug Fixes
+
+* Fixed Object.assign not existing on older devices
+
 ## Version 2.7.5 - 23rd March 2017
 
 * A hotfix to patch the error `this.preUpdateLifeSpan is not a function` in 2.7.4 (#72)

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -154,3 +154,31 @@ if (!window.console)
     window.console.log = window.console.assert = function(){};
     window.console.warn = window.console.assert = function(){};
 }
+
+/**
+ * Fix for Object.assign not existing on older devices
+ */
+if (typeof Object.assign != 'function') {
+  Object.assign = function(target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}


### PR DESCRIPTION
Object.assign was only recently added, so older devices don't support it. This checks if the Object.assign function exists, and if it doesn't, an alternative function is created.