### PR TITLE
Fixed typescript definitions for getTile

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ## Version 2.7.6
 
-## Bug Fixes
+### Bug Fixes
 
 * Fixed Object.assign not existing on older devices
+* Fixed typescript definitions for `TilemapLayer#getRayCastTiles`, `TilemapLayer#getTiles`, `TilemapLayer#getTileX`, `TilemapLayer#getTileXY` and `TilemapLayer#getTileY`
 
 ## Version 2.7.5 - 23rd March 2017
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -5155,11 +5155,11 @@ declare module Phaser {
         wrap: boolean;
 
         destroy(): void;
-        getRayCastTiles(layer: Phaser.TilemapLayer|Phaser.TilemapLayerGL, line: Phaser.Line, stepRate?: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
-        getTiles(layer: Phaser.TilemapLayer|Phaser.TilemapLayerGL, x: number, y: number, width: number, height: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
-        getTileX(layer: Phaser.TilemapLayer|Phaser.TilemapLayerGL, x: number): number;
-        getTileXY(layer: Phaser.TilemapLayer|Phaser.TilemapLayerGL, x: number, y: number, point: Phaser.Point): Phaser.Point;
-        getTileY(layer: Phaser.TilemapLayer|Phaser.TilemapLayerGL, y: number): number;
+        getRayCastTiles(line: Phaser.Line, stepRate?: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
+        getTiles(x: number, y: number, width: number, height: number, collides?: boolean, interestingFace?: boolean): Phaser.Tile[];
+        getTileX(x: number): number;
+        getTileXY(x: number, y: number, point: Phaser.Point): Phaser.Point;
+        getTileY(y: number): number;
         postUpdate(): void;
         render(): void;
         resize(width: number, height: number): void;


### PR DESCRIPTION
* TypeScript Defs

Fixed typescript definition files of `TilemapLayer#getRayCastTiles`, `TilemapLayer#getTiles`, `TilemapLayer#getTileX`, `TilemapLayer#getTileXY` and `TilemapLayer#getTileY`

Fixes #75 