### PR TITLE
Added missing  properties to Phaser.Graphics - phaser.d.ts

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1669,6 +1669,8 @@ declare module Phaser {
         body: Phaser.Physics.Arcade.Body | Phaser.Physics.P2.Body | Phaser.Physics.Ninja.Body | any;
         bottom: number;
         cameraOffset: Phaser.Point;
+        centerX: number;
+		centerY: number;
         checkWorldBounds: boolean;
         components: any;
         data: any;


### PR DESCRIPTION
This PR changes (delete as applicable)

TypeScript Defs
Describe the changes below:
Added centerX and centerY properties to Phaser.Graphics.
According to the API docs it should be exposed as public. prop.

