### PR TITLE
Update Game.js

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -810,7 +810,7 @@ Phaser.Game.prototype = {
         {
             this.stage.smoothed = this.antialias;
 
-            Phaser.Canvas.addToDOM(this.canvas, this.parent, false);
+            this.parent = Phaser.Canvas.addToDOM(this.canvas, this.parent, false);
             Phaser.Canvas.setTouchAction(this.canvas);
         }
 


### PR DESCRIPTION
This PR changes  The public-facing API

Describe the changes below:
Judging from the Typescript definitions the parent property of `Phaser.Game` should contain `HTMLElement`. Now when you initialize the `Phaser.Game` using a element id as a string, it will only reference the id not the actual `HTMLElement` it's been added to. 

#126 
