### PR TITLE
Don't read null events in Phaser.Keyboard#lastChar

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ### Bug Fixes
 
+* Phaser.Keyboard#lastChar is now `null` if Phaser has recorded no key presses yet. It no longer throws an error (#132).
 * Previously, the `center` of a moving Arcade Physics Body was inaccurate during the game's update phase, and that made collision checks of circular Bodies less accurate (#122). This was fixed by updating `center` during preUpdate.
 * Fixed an issue when dragging a sprite whose parent is scaled or rotated (#108). Now the sprite follows the cursor correctly.
 * Fixed audio skipping when restarting playback (#78)

--- a/src/input/Keyboard.js
+++ b/src/input/Keyboard.js
@@ -487,7 +487,7 @@ Phaser.Keyboard.prototype = {
     /**
     * Returns `true` if the Key was pressed down within the `duration` value given, or `false` if it either isn't down,
     * or was pressed down longer ago than then given duration.
-    * 
+    *
     * @method Phaser.Keyboard#downDuration
     * @param {integer} keycode - The {@link Phaser.KeyCode keycode} of the key to check: i.e. Phaser.KeyCode.UP or Phaser.KeyCode.SPACEBAR.
     * @param {number} [duration=50] - The duration within which the key is considered as being just pressed. Given in ms.
@@ -509,7 +509,7 @@ Phaser.Keyboard.prototype = {
     /**
     * Returns `true` if the Key was pressed down within the `duration` value given, or `false` if it either isn't down,
     * or was pressed down longer ago than then given duration.
-    * 
+    *
     * @method Phaser.Keyboard#upDuration
     * @param {Phaser.KeyCode|integer} keycode - The keycode of the key to check, i.e. Phaser.KeyCode.UP or Phaser.KeyCode.SPACEBAR.
     * @param {number} [duration=50] - The duration within which the key is considered as being just released. Given in ms.
@@ -586,13 +586,17 @@ Object.defineProperty(Phaser.Keyboard.prototype, "lastChar", {
 
     get: function () {
 
-        if (this.event.charCode === 32)
+        if (this.event && this.event.charCode === 32)
         {
             return '';
         }
-        else
+        else if (this.pressEvent)
         {
             return String.fromCharCode(this.pressEvent.charCode);
+        }
+        else
+        {
+            return null;
         }
 
     }


### PR DESCRIPTION
This PR changes: a bug fix (#132)