### PR TITLE
Fixes #157 Extended audiotag volume clamping to all browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 <a name="change-log"></a>
 # Change Log
 
+## Version 2.7.7 - TBA
+
+* Fixed Phaser.Sound exception when using IE with AudioTag and high volume values (#157), from now on volume clamping happens in every AudioTag supported browser.
+
 ## Version 2.7.6 - 13th April 2017
 
 ### New Features

--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -1212,8 +1212,8 @@ Object.defineProperty(Phaser.Sound.prototype, "volume", {
 
     set: function (value) {
 
-        //  Causes an Index size error in Firefox if you don't clamp the value
-        if (this.game.device.firefox && this.usingAudioTag)
+        //  Causes an Index size error if you don't clamp the value
+        if (this.usingAudioTag)
         {
             value = this.game.math.clamp(value, 0, 1);
         }


### PR DESCRIPTION
This PR is a bug fix for #157
Extended audiotag volume clamping to all browsers, according to the documentation audiotag volume must between 0 and 1 (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio)