### PR TITLE
Don't update game.particles during game.updateLogic()

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ### Bug Fixes
 
+* Fixed particle [autoAlpha](https://photonstorm.github.io/phaser-ce/Phaser.Particles.Arcade.Emitter.html#autoAlpha) and [autoScale](https://photonstorm.github.io/phaser-ce/Phaser.Particles.Arcade.Emitter.html#autoScale) tweens running at double speed (#160).
 * Fixed loading of compressed textures (#17, #162)
 * Removed `any` key in [Phaser.Physics.Arcade.Body#checkCollision](https://photonstorm.github.io/phaser-ce/Phaser.Physics.Arcade.Body.html#checkCollision). It was never used, so setting it had no effect (#161). Use `!checkCollision.none` instead.
 * Fixed Phaser.Sound exception when using IE with AudioTag and high volume values (#157), from now on volume clamping happens in every AudioTag supported browser.

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -977,7 +977,6 @@ Phaser.Game.prototype = {
             this.sound.update();
             this.input.update();
             this.physics.update();
-            this.particles.update();
             this.plugins.update();
 
             this.stage.postUpdate();

--- a/src/particles/Particles.js
+++ b/src/particles/Particles.js
@@ -54,9 +54,13 @@ Phaser.Particles.prototype = {
     },
 
     /**
-    * Called by the core game loop. Updates all Emitters who have their exists value set to true.
+    * Updates all Emitters who have their exists value set to true.
+    *
+    * Phaser no longer uses this method; Emitters receive updates via {@link Phaser.Stage#update} instead.
+    *
     * @method Phaser.Particles#update
     * @protected
+    * @deprecated
     */
     update: function () {
         for (var key in this.emitters)


### PR DESCRIPTION
Fixes #160

Also deprecates Phaser.Particles#update since Phaser no longer uses it