### PR TITLE
Allow setting maxParallelDownloads to higher values

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 # Change Log
 
+## Version 2.7.8 - Unreleased
+
+### Updates
+
+* Allow setting maxParallelDownloads to higher values (#170)
+
 ## Version 2.7.7 - 20th April 2017
 
 ### Bug Fixes

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -215,8 +215,9 @@ Phaser.Loader = function (game) {
     *
     * Many current browsers limit 6 requests per domain; this is slightly conservative.
     *
+    * This should generally be left at the default, but can be set to a higher limit for specific use-cases. Just be careful when setting large values as different browsers could behave differently.
+    *
     * @property {integer} maxParallelDownloads
-    * @protected
     */
     this.maxParallelDownloads = 4;
 
@@ -1934,7 +1935,7 @@ Phaser.Loader.prototype = {
         // When true further non-pack file downloads are suppressed
         var syncblock = false;
 
-        var inflightLimit = this.enableParallel ? Phaser.Math.clamp(this.maxParallelDownloads, 1, 12) : 1;
+        var inflightLimit = this.enableParallel ? Math.max(1, this.maxParallelDownloads) : 1;
 
         for (var i = this._processingHead; i < this._fileList.length; i++)
         {


### PR DESCRIPTION
This removes the upper limit of 12 from `maxParallelDownloads` in the `Loader` and addresses #170. The default remains at 4 while allowing the user to set the value to anything from `1` to `Infinity`.