### PR TITLE
Add types for style parameters in Typescript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 * Clarified Phaser.Image's use of the Animation component (#185). Images can actually play animations just like Sprites.
 * [Phaser CE API](https://photonstorm.github.io/phaser-ce/) now shows a synopsis. You can still find the complete [README](https://github.com/photonstorm/phaser-ce/blob/master/README.md) on GitHub.
 * Allow setting maxParallelDownloads to higher values (#170)
+* Added missing types to Typescript definitions
 
 ### Bug Fixes
 

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -8177,7 +8177,7 @@ declare module Phaser {
         * @param style The style object containing style attributes like font, font size , etc.
         * @return The newly created text object.
         */
-        text(x: number, y: number, text?: string, style?: any): Phaser.Text;
+        text(x: number, y: number, text?: string, style?: PhaserTextStyle): Phaser.Text;
 
         /**
         * Creates a new Phaser.Tilemap object.
@@ -8524,7 +8524,7 @@ declare module Phaser {
         * @param group Optional Group to add the object to. If not specified it will be added to the World group.
         * @return The newly created text object.
         */
-        text(x?: number, y?: number, text?: string, style?: any, group?: Phaser.Group): Phaser.Text;
+        text(x?: number, y?: number, text?: string, style?: PhaserTextStyle, group?: Phaser.Group): Phaser.Text;
 
         /**
         * Creates a new Phaser.Tilemap object.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1514,7 +1514,7 @@ declare module Phaser {
         sound(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         sprite(x: number, y: number, key?: any, frame?: any): Phaser.Sprite;
         spriteBatch(parent: any, name?: String, addToStage?: boolean): Phaser.SpriteBatch;
-        text(x: number, y: number, text?: string, style?: any): Phaser.Text;
+        text(x: number, y: number, text?: string, style?: PhaserTextStyle): Phaser.Text;
         tilemap(key: string, tileWidth?: number, tileHeight?: number, width?: number, height?: number): Phaser.Tilemap;
         tileSprite(x: number, y: number, width: number, height: number, key: any, frame: any): Phaser.TileSprite;
         tween(obj: any): Phaser.Tween;
@@ -1547,7 +1547,7 @@ declare module Phaser {
         sound(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         sprite(x?: number, y?: number, key?: any, frame?: any, group?: Phaser.Group): Phaser.Sprite;
         spriteBatch(parent: any, name?: string, addToStage?: boolean): Phaser.Group;
-        text(x?: number, y?: number, text?: string, style?: any, group?: Phaser.Group): Phaser.Text;
+        text(x?: number, y?: number, text?: string, style?: PhaserTextStyle, group?: Phaser.Group): Phaser.Text;
         tilemap(key?: string, tileWidth?: number, tileHeight?: number, width?: number, height?: number): Phaser.Tilemap;
         tileSprite(x: number, y: number, width: number, height: number, key?: any, frame?: any, group?: Phaser.Group): Phaser.TileSprite;
         tween(obj: any): Phaser.Tween;


### PR DESCRIPTION
This PR changes
* TypeScript Defs

Describe the changes below:
Replaced 'any' with 'PhaserTextStyle' for style parameters in GameObjectFactory#text and GameObjectCreator#text. These now line up with the type used in the Text constructor.

This enables autocompleting of fields within a style object when using the .add and .make syntax.