### PR TITLE
Text now handles alignment being set in upper or mixed case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 * Fixed some Typescript definitions (#167)
 * Fixed issue with missing `var` keywords leading to runtime exceptions in `src/pixi/renderers/webgl/WebGLRenderer.js`
 * Fixed runtime exception in `src/pixi/renderers/webgl/utils/WebGLGraphics.js` when `renderGraphics` was called with a `graphics` without webGL context (#178)
+* Fixed issue where text alignment could only be set with lower case, but was not enforced. Mixed and upper case now work as well
 
 ## Version 2.7.7 - 20th April 2017
 

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -316,9 +316,9 @@ Phaser.Text.prototype.setStyle = function (style, update) {
     newStyle.font = style.font || 'bold 20pt Arial';
     newStyle.backgroundColor = style.backgroundColor || null;
     newStyle.fill = style.fill || 'black';
-    newStyle.align = style.align || 'left';
-    newStyle.boundsAlignH = style.boundsAlignH || 'left';
-    newStyle.boundsAlignV = style.boundsAlignV || 'top';
+    newStyle.align = style.align.toLowerCase() || 'left';
+    newStyle.boundsAlignH = style.boundsAlignH.toLowerCase() || 'left';
+    newStyle.boundsAlignV = style.boundsAlignV.toLowerCase() || 'top';
     newStyle.stroke = style.stroke || 'black'; //provide a default, see: https://github.com/GoodBoyDigital/pixi.js/issues/136
     newStyle.strokeThickness = style.strokeThickness || 0;
     newStyle.wordWrap = style.wordWrap || false;
@@ -1922,6 +1922,7 @@ Object.defineProperty(Phaser.Text.prototype, 'align', {
 
     set: function(value) {
 
+        value = value.toLowerCase();
         if (value !== this.style.align)
         {
             this.style.align = value;
@@ -1996,6 +1997,7 @@ Object.defineProperty(Phaser.Text.prototype, 'boundsAlignH', {
 
     set: function(value) {
 
+        value = value.toLowerCase();
         if (value !== this.style.boundsAlignH)
         {
             this.style.boundsAlignH = value;
@@ -2019,6 +2021,7 @@ Object.defineProperty(Phaser.Text.prototype, 'boundsAlignV', {
 
     set: function(value) {
 
+        value = value.toLowerCase();
         if (value !== this.style.boundsAlignV)
         {
             this.style.boundsAlignV = value;


### PR DESCRIPTION
This PR changes
* Nothing, it's a bug fix

Describe the changes below:
Phaser.Text can have it's alignment set as any arbitrary string, but was only compared against lowercase left/middle/right. string#toLowerCase() is now called on the alignment before comparison.