### PR TITLE
Get all children of a group if no property parameter is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ### Bug Fixes
 
+* Group#getAll was not returning all children objects when property was not specified.
+
 ## Version 2.7.9 - 9th May 2017
 
 ### Updates

--- a/src/core/Group.js
+++ b/src/core/Group.js
@@ -2446,7 +2446,14 @@ Phaser.Group.prototype.getAll = function (property, value, startIndex, endIndex)
     {
         var child = this.children[i];
 
-        if (property && child[property] === value)
+        if (property)
+        {
+            if (child[property] === value)
+            {
+                output.push(child);
+            }
+        }
+        else
         {
             output.push(child);
         }


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

Describe the changes below:

The documentation implies that property is an optional parameter, however the getAll() function will only return an empty array if no property parameter is provided.