### PR TITLE
Reduce npm package size.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,11 @@
 dist/
 docs/
 resources/
-
-.*
+.git*
+.jshintrc
+.npmignore
+.travis.yml
+.editorconfig
 *.md
 bower.json
 phaser-ce-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+dist/
+docs/
+resources/
+
+.*
+*.md
+bower.json
+phaser-ce-*.tgz


### PR DESCRIPTION
Hi, @samme, @photonstorm.

I'm sending this PR as a proposal to make some adjustements to the Phaser CE package. It is not a big change (just only an additional file), but it changes the contents distributed through npm. I'd like to ask you to review this change carefully. I am able to update this PR, if requested.

The problem is that `phaser-ce` package is too big, much because it includes contents not relevant for a npm package. Right now, running `npm pack .` against the master branch will create a TAR+GZIP archive which sits at around 36MB of size, ~94MB uncompressed ─ Think of `npm pack` as a "dry-run mode" of `npm publish`.

My proposal is to remove, among other things:

*   The `resources` folder, which contains miscellaneous files;

*   The Grunt tasks, because it is unusual to keep those files in a distribution package;

*   The documentation folder, because it is more convenient to read it either using a repository clone or the [GitHub page](photonstorm.github.io/phaser-ce/).

With these changes applied, the package size should be reduced to around ~6.9MB, and ~33MB uncompressed, around 1/3 of the original size but still a little big because of all source maps and a few duplicate files under `build/custom`, which you should check later.

One question I have is about the `filters/` folder, which contains some useful content. I opted to keep those files in the package, but I wonder how users are consuming those files. Perhaps those files should be published as a separate package.

---

References:

1. [npm-pack](https://docs.npmjs.com/cli/pack)
2. [npm-developers § Keeping files _out_ of your package](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package)
