### PR TITLE
Set x and y scale when the values are identical

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ### Bug Fixes
 
+* Emitter#emitParticle apply scale values even when they are identicals.
 * Fixed a crash when a Text object's alignment was not set (#208).
 
 For changes in previous releases please see the extensive [Version History](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md).

--- a/src/particles/arcade/Emitter.js
+++ b/src/particles/arcade/Emitter.js
@@ -651,6 +651,10 @@ Phaser.Particles.Arcade.Emitter.prototype.emitParticle = function (x, y, key, fr
     {
         particle.scale.set(rnd.realInRange(this._minParticleScale.x, this._maxParticleScale.x), rnd.realInRange(this._minParticleScale.y, this._maxParticleScale.y));
     }
+    else
+    {
+        particle.scale.set(this._minParticleScale.x, this._minParticleScale.y)
+    }
 
     if (frame === undefined)
     {


### PR DESCRIPTION
This PR changes

* Nothing, it's a bug fix

The problem is that setting `emmiter.setScale(-1, -1)` is doing nothing. because if expects different values. This is an attemps to fix that.
