### PR TITLE
Version 2.7.9 doesn't exist as a CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ Using Browserify? Please [read this](#browserify).
 
 [Phaser CE is on jsDelivr](http://www.jsdelivr.com/projects/phaser-ce), a "super-fast CDN for developers". Include the following in your html:
 
-    <script src="//cdn.jsdelivr.net/phaser-ce/2.7.9/phaser.js"></script>
+    <script src="//cdn.jsdelivr.net/phaser-ce/2.7.7/phaser.js"></script>
 
 or the minified version:
 
-    <script src="//cdn.jsdelivr.net/phaser-ce/2.7.9/phaser.min.js"></script>
+    <script src="//cdn.jsdelivr.net/phaser-ce/2.7.7/phaser.min.js"></script>
 
 ### Web Templates
 


### PR DESCRIPTION
Changed to 2.7.7 in the meantime, which does.

Make sure you describe your PR in the [README Change Log](../README.md#change-log) section!

This PR changes (✏️ delete as applicable)

* Documentation
* TypeScript Defs
* The public-facing API
* Nothing, it's a bug fix

Describe the changes below:
