### PR TITLE
Make Point.equals(null) return false

### DIFF
--- a/src/geom/Point.js
+++ b/src/geom/Point.js
@@ -274,7 +274,7 @@ Phaser.Point.prototype = {
     */
     equals: function (a) {
 
-        return (a.x === this.x && a.y === this.y);
+        return (a && a.x === this.x && a.y === this.y);
 
     },
 


### PR DESCRIPTION
This PR changes (✏️ delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:

Point.equals(x) will return false when passed a null value