### PR TITLE
Set timer to expired on destroy

### DIFF
--- a/src/time/Timer.js
+++ b/src/time/Timer.js
@@ -653,6 +653,7 @@ Phaser.Timer.prototype = {
 
         this.onComplete.removeAll();
         this.running = false;
+        this.expired = true;
         this.events = [];
         this._len = 0;
         this._i = 0;


### PR DESCRIPTION
If you try to destroy a looping timer, it will never actually get removed from the `game.time._timers` array because `expired` never gets set to `true`. Directly setting `expired = true` in `destroy` seems to fix this issue.