### PR TITLE
Xesenix patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 # Change Log
 
+### Bug Fixes
+
+* Fixed keeping track of global volume for Audio Tag Sounds (fadeTo didnt respect global volume set by SoundManager) 
+
 ## Version 2.7.10 - 19th May 2017
 
 ### New Features

--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -175,6 +175,12 @@ Phaser.Sound = function (game, key, volume, loop, connect) {
     */
     this._sound = null;
 
+	/**
+    * @property {object} _globalVolume - Internal var for keeping track of global volume when using AudioTag
+    * @private
+    */
+	this._globalVolume = 1;
+
     /**
     * @property {boolean} _markedToDelete - When audio stops, disconnect Web Audio nodes.
     * @private
@@ -1074,7 +1080,8 @@ Phaser.Sound.prototype = {
 
         if (this.usingAudioTag && this._sound)
         {
-            this._sound.volume = globalVolume * this._volume;
+            this._globalVolume = globalVolume;
+            this._sound.volume = this._globalVolume * this._volume;
         }
 
     },
@@ -1233,7 +1240,7 @@ Object.defineProperty(Phaser.Sound.prototype, "volume", {
         }
         else if (this.usingAudioTag && this._sound)
         {
-            this._sound.volume = value;
+            this._sound.volume = this._globalVolume * value;
         }
     }
 


### PR DESCRIPTION
This PR changes:
* Nothing, it's a bug fix

Describe the changes below:

When using Audio Tag and setting global volume and then using something like fadeTo sound volume on Audio Tag ignores global volume this fixes that. This problem is Audio Tag specific WebAudio works correctly without this fix.

You can notice this when after lowering global volume you turn on some fadeOut sound transition you can hear volume spike in beginning of this transition.