### PR TITLE
Typings typo fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@ We've bumped the minor version (2.8) for changes in how circular Arcade Physics 
 * Fixed incorrect Phaser.Text dimensions when assigning a numeric string to [strokeThickness](https://photonstorm.github.io/phaser-ce/Phaser.Text.html#strokeThickness) (#239). (You should still use a number instead, though.)
 * Fixed Sounds ignoring changes to global volume when using audio tags.
 * Fixed looping timers not getting removed completely when destroyed.
+* Fixed typo for typescript definition of IGameConfig.multiTexture property
 
 ### Thanks
 
-@ColaColin, @GameDevFox, @goldfire, @netgfx, @photonstorm, @rblopes, @samme, @shunsei, @Xesenix
+@ColaColin, @GameDevFox, @goldfire, @netgfx, @photonstorm, @rblopes, @samme, @shunsei, @Xesenix, @Formic
 
 ## Version 2.7.10 - 19th May 2017
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1408,7 +1408,7 @@ declare module Phaser {
         seed?: string;
         state?: Phaser.State;
         forceSetTimeOut?: boolean;
-        multiTextue?: boolean;
+        multiTexture?: boolean;
 
     }
 


### PR DESCRIPTION
Make sure you describe your PR in the [README Change Log](https://github.com/photonstorm/phaser-ce/blob/master/README.md#change-log) section!

This PR changes (✏️ delete as applicable)

* TypeScript Defs

Describe the changes below:

I updated the phaser.d.ts file. The multiTexture property was mistyped multiTextue. I'm pretty n00b when it comes to typings, so if I changed it at the wrong place or something, please let me know and I will correct it.
