### PR TITLE
Fix camera shake #246

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 * Fixed typo for typescript definition of `IGameConfig.multiTexture` property.
 * Fixed `NaN` value for some objects' `worldRotation` and `worldScale` properties. `worldTransform` was still correct.
+* Fixed camera shake failing to be set to 0 when camera is reset.
 
 ## Version 2.8.0 - 30th May 2017
 

--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -773,6 +773,8 @@ Phaser.Camera.prototype = {
         this.view.y = 0;
 
         this._shake.duration = 0;
+        this._shake.x = 0;
+        this._shake.y = 0;
 
         this.resetFX();
 


### PR DESCRIPTION
Camera._shake.x and y weren't being set to 0 on camera reset, causing
the camera to get stuck in the wrong position.