### PR TITLE
Fixed hittest not taking device resolution into account

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -982,8 +982,8 @@ Phaser.Input.prototype = {
         }
         else if (displayObject instanceof PIXI.Sprite)
         {
-            var width = displayObject.texture.frame.width;
-            var height = displayObject.texture.frame.height;
+            var width = displayObject.texture.frame.width / displayObject.texture.baseTexture.resolution;
+            var height = displayObject.texture.frame.height / displayObject.texture.baseTexture.resolution;
             var x1 = -width * displayObject.anchor.x;
 
             if (this._localPoint.x >= x1 && this._localPoint.x < x1 + width)


### PR DESCRIPTION
Make sure you describe your PR in the [README Change Log](https://github.com/photonstorm/phaser-ce/blob/master/README.md#change-log) section!

This PR changes (✏️ delete as applicable)

* Nothing, it's a bug fix

Describe the changes below:
Fixed hitTest function not taking device resolution into account when an image resolution is added dynamically using @{n}x notation on a asset.  