### PR TITLE
Fix TypeScript definitions for move callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 * Fixed definitions of Phaser.Matrix and Phaser.RenderTexture (#174, #270).
 * The debug canvas is returned to the canvas pool when the game is destroyed (#269).
+* Fixed definitions of Phaser.Input.moveCallbacks, Phaser.Input.addMoveCallback and Phaser.Input.deleteMoveCallback (#274).
 
 ## Version 2.8.1 - 20th June 2017
 

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -11620,7 +11620,7 @@ declare module Phaser {
         * An array of callbacks that will be fired every time the activePointer receives a move event from the DOM.
         * To add a callback to this array please use `Input.addMoveCallback`.
         */
-        moveCallbacks: (pointer: Phaser.Pointer, x: number, y: number) => void[];
+        moveCallbacks: { callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any }[];
 
         /**
         * The MSPointer Input manager.
@@ -11830,7 +11830,7 @@ declare module Phaser {
         * @param callback The callback that will be called each time the activePointer receives a DOM move event.
         * @param context The context in which the callback will be called.
         */
-        addMoveCallback(callback: Function, context: any): number;
+        addMoveCallback(callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any): void;
 
         /**
         * Starts the Input Manager running.
@@ -11844,7 +11844,7 @@ declare module Phaser {
         * @param callback The callback to be removed.
         * @param context The context in which the callback exists.
         */
-        deleteMoveCallback(callback: Function, context?: any): void;
+        deleteMoveCallback(callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any): void;
 
         /**
         * Stops all of the Input Managers from running.

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1971,7 +1971,7 @@ declare module Phaser {
         minPriorityID: number;
         mouse: Phaser.Mouse;
         mousePointer: Phaser.Pointer;
-        moveCallbacks: (pointer: Phaser.Pointer, x: number, y: number) => void[];
+        moveCallbacks: { callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any }[];
         mspointer: Phaser.MSPointer;
         multiInputOverride: number;
         onDown: Phaser.Signal;
@@ -2008,10 +2008,10 @@ declare module Phaser {
         y: number;
 
         addPointer(): Phaser.Pointer;
-        addMoveCallback(callback: Function, context: any): number;
+        addMoveCallback(callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any): void;
         boot(): void;
         countActivePointers(limit?: number): number;
-        deleteMoveCallback(callback: Function, context?: any): void;
+        deleteMoveCallback(callback: (pointer: Phaser.Pointer, x: number, y: number, fromClick: boolean) => void, context?: any): void;
         destroy(): void;
         getLocalPosition(displayObject: any, pointer: Phaser.Pointer): Phaser.Point;
         getPointer(isActive?: boolean): Phaser.Pointer;


### PR DESCRIPTION
Make sure you describe your PR in the [README Change Log](https://github.com/photonstorm/phaser-ce/blob/master/README.md#change-log) section!

This PR changes (✏️ delete as applicable)

* TypeScript Defs

Describe the changes below:

Playing around with move callbacks, I noticed the TypeScript definitions differed a little from the actual implementation:
- Phaser.Input.moveCallbacks: certainly not a single closure returning a void-array, but an array of objects containing both a callback and a context to execute the callback in. Also the `fromClick` parameter was missing from the callback signature.
- Phaser.Input.addMoveCallback: added the full callback signature for better type-checking. Changed the return type form `number` to `void`, since it doesn't actually return anything. Made the context optional to match the parameters of deleteMoveCallback.
- Phaser.Input.deleteMoveCallback: added the full callback signature for better type-checking.