### PR TITLE
Typescript : missing scaleMode parameter for IGameConfig

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1409,7 +1409,8 @@ declare module Phaser {
         state?: Phaser.State;
         forceSetTimeOut?: boolean;
         multiTexture?: boolean;
-
+        scaleMode?: number;
+        
     }
 
     class Game {


### PR DESCRIPTION
Make sure you describe your PR in the [README Change Log](https://github.com/photonstorm/phaser-ce/blob/master/README.md#change-log) section!

This PR changes (✏️ delete as applicable)

* TypeScript Defs

Describe the changes below:
I've noticed **scaleMode** parameter is missing from typescript **IGameConfig** definition. The parameter is available into phaser-ce documentation.

Tell me if i did something wrong (It's been a while i did not make a pull request from github). ;)
