### PR TITLE
Fixing bug with TileSprite tint not working correctly when rendering …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 See [README: Change Log](README.md#change-log).
 
+### Bug Fixes
+
+* TileSprite tint now works when rendering with Canvas
+
+### Thanks
+
+@Formic
+
 ## Version 2.8.3 - 21st July 2017
 
 ### Updates

--- a/src/gameobjects/TileSprite.js
+++ b/src/gameobjects/TileSprite.js
@@ -423,7 +423,16 @@ Phaser.TileSprite.prototype._renderCanvas = function (renderSession) {
     var tx = (wt.tx * resolution) + renderSession.shakeX;
     var ty = (wt.ty * resolution) + renderSession.shakeY;
 
-    context.setTransform(wt.a * resolution, wt.b * resolution, wt.c * resolution, wt.d * resolution, tx, ty);
+    context.setTransform(wt.a * resolution, wt.b * resolution, wt.c * resolution, wt.d * resolution, tx, ty);    
+
+    if (this.tint !== 0xFFFFFF && (this.texture.requiresReTint || this.cachedTint !== this.tint))
+    {
+        this.tintedTexture = PIXI.CanvasTinter.getTintedTexture(this, this.tint);
+
+        this.cachedTint = this.tint;
+        this.texture.requiresReTint = false;
+        this.refreshTexture = true;        
+    }
 
     if (this.refreshTexture)
     {
@@ -579,8 +588,10 @@ Phaser.TileSprite.prototype.generateTilingTexture = function (forcePowerOfTwo) {
         h = targetHeight;
     }
 
+    var targetTexture = this.tintedTexture ? this.tintedTexture : texture.baseTexture.source;
+
     this.canvasBuffer.context.drawImage(
-        texture.baseTexture.source,
+        targetTexture,
         texture.crop.x,
         texture.crop.y,
         texture.crop.width,


### PR DESCRIPTION
…in Canvas

Resolves issue #294

This PR changes
* Nothing, it's a bug fix

Describe the changes below:

I pulled the added code from the Sprite class, only slightly modifying it to fit the way the TileSprite works differently than the Sprite. I'm no PIXI expert, so perhaps I am not covering every case or doing this inappropriately, and I'd love to fix it if that is the case. AFAIK, this was the appropriate place for the code, and it has fixed the issue.
