### PR TITLE
Correct documentation for InputHandler#enableDrag

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ## Unreleased
 
+* Corrects documentation for InputHandler#enableDrag (alphaThreshold is not boolean).
+
 ### New Features
 
 ### Updates

--- a/src/input/InputHandler.js
+++ b/src/input/InputHandler.js
@@ -1405,7 +1405,7 @@ Phaser.InputHandler.prototype = {
     * @param {boolean} [lockCenter=false] - If false the Sprite will drag from where you click it minus the dragOffset. If true it will center itself to the tip of the mouse pointer.
     * @param {boolean} [bringToTop=false] - If true the Sprite will be bought to the top of the rendering list in its current Group.
     * @param {boolean} [pixelPerfect=false] - If true it will use a pixel perfect test to see if you clicked the Sprite. False uses the bounding box.
-    * @param {boolean} [alphaThreshold=255] - If using pixel perfect collision this specifies the alpha level from 0 to 255 above which a collision is processed.
+    * @param {integer} [alphaThreshold=255] - If using pixel perfect collision this specifies the alpha level from 0 to 255 above which a collision is processed.
     * @param {Phaser.Rectangle} [boundsRect=null] - If you want to restrict the drag of this sprite to a specific Rectangle, pass the Phaser.Rectangle here, otherwise it's free to drag anywhere.
     * @param {Phaser.Sprite} [boundsSprite=null] - If you want to restrict the drag of this sprite to within the bounding box of another sprite, pass it here.
     */


### PR DESCRIPTION
* changes documentation

- [v] This PR includes a description of these changes in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased).

Describe the changes below:

alphaThreshold was documented as a boolean despite being an integer.