### PR TITLE
Animation synchronization problem and solution

### DIFF
--- a/src/animation/Animation.js
+++ b/src/animation/Animation.js
@@ -421,6 +421,10 @@ Phaser.Animation.prototype = {
                 this._frameSkip = Math.floor(this._frameDiff / this.delay);
                 this._frameDiff -= (this._frameSkip * this.delay);
             }
+			else
+			{
+				this._frameDiff = 0;
+			}
 
             //  And what's left now?
             this._timeNextFrame = this.game.time.time + (this.delay - this._frameDiff);


### PR DESCRIPTION
* is a bug fix

-----------------------

There was a problem with Animations where there would be lagging or sped up animations due to lower framerate than what Phaser expects.
The first frame a delay is detected, it compensates perfectly, but on the succeeding frames, it compensates too much and disynchronises animations.

This is our fix for the Animation problem we encountered and we wanted to share this with CE.

We hope it will help some people have an easier time with anims on slower devices such as small tablets or old phones.

-----------------------