### PR TITLE
Use inverted logic from Pointer#processButtonsDown for Pointer#processButtonsUp

### DIFF
--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -488,34 +488,34 @@ Phaser.Pointer.prototype = {
     * @param {integer} button - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button MouseEvent#button} value.
     * @param {MouseEvent} event - The DOM event.
     */
-    processButtonsUp: function (button, event) {
+    processButtonsUp: function (buttons, event) {
 
-        if (button === Phaser.Mouse.LEFT_BUTTON)
+        if (Phaser.Pointer.LEFT_BUTTON & ~buttons)
         {
             this.leftButton.stop(event);
         }
 
-        if (button === Phaser.Mouse.RIGHT_BUTTON)
+        if (Phaser.Pointer.RIGHT_BUTTON & ~buttons)
         {
             this.rightButton.stop(event);
         }
 
-        if (button === Phaser.Mouse.MIDDLE_BUTTON)
+        if (Phaser.Pointer.MIDDLE_BUTTON & ~buttons)
         {
             this.middleButton.stop(event);
         }
 
-        if (button === Phaser.Mouse.BACK_BUTTON)
+        if (Phaser.Pointer.BACK_BUTTON & ~buttons)
         {
             this.backButton.stop(event);
         }
 
-        if (button === Phaser.Mouse.FORWARD_BUTTON)
+        if (Phaser.Pointer.FORWARD_BUTTON & ~buttons)
         {
             this.forwardButton.stop(event);
         }
 
-        if (button === 5)
+        if (Phaser.Pointer.ERASER_BUTTON & ~buttons)
         {
             this.eraserButton.stop(event);
         }
@@ -544,7 +544,7 @@ Phaser.Pointer.prototype = {
             }
             else
             {
-                this.processButtonsUp(event.button, event);
+                this.processButtonsUp(event.buttons, event);
             }
         }
         else

--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -485,7 +485,7 @@ Phaser.Pointer.prototype = {
     *
     * @method Phaser.Pointer#processButtonsUp
     * @private
-    * @param {integer} button - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button MouseEvent#button} value.
+    * @param {integer} buttons - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons MouseEvent#buttons} value.
     * @param {MouseEvent} event - The DOM event.
     */
     processButtonsUp: function (buttons, event) {


### PR DESCRIPTION
This fixes forward and backward button (once pressed isDown stayed true) and correlated onInputUp for buttons being stuck, etc.

This PR

* is a bug fix

Note: I tested this in Firefox (because my Chrome can't do anything but leftclick) but generally I just copied processButtonsDown, inverted the bits and replaced start() with stop(). Shouldn't break anything, right?

//EDIT: Meh I forgot to change the documentation naming, shall I squash these two commits?

[Compiled version for testing](https://gs.breitzeit.de/phaser/builds/phaser-fix_fbb_i318.js)