### PR TITLE
Fix PIXI.Sprite.setTexture destroying old texture when destroyBase is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,11 @@ If you code with [TypeScript](http://www.typescriptlang.org/) there are comprehe
 
 ### Bug Fixes
 
+* Fixed sprite texture being destroyed in [setTexture](https://photonstorm.github.io/phaser-ce/PIXI.Sprite.html#setTexture) if `destroyBase` is set to false.
+
 ### Thanks
 
-@goldfire, @rafelsanso
+@goldfire, @rafelsanso, @ryanrossiter
 
 ## Version 2.8.4 - 15th August 2017
 

--- a/src/pixi/display/Sprite.js
+++ b/src/pixi/display/Sprite.js
@@ -179,7 +179,7 @@ Object.defineProperty(PIXI.Sprite.prototype, 'height', {
  */
 PIXI.Sprite.prototype.setTexture = function(texture, destroyBase)
 {
-    if (destroyBase !== undefined)
+    if (destroyBase)
     {
         this.texture.baseTexture.destroy();
     }


### PR DESCRIPTION
This PR:
* is a bug fix

* [x] Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.

Describe the changes below:
* Fix check of destroyBase in PIXI.Sprite.setTexture to not destroy old texture if set to false