### PR TITLE
No camera shake applied bugfix

### DIFF
--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -525,6 +525,9 @@ Phaser.Camera.prototype = {
             this._shake.y = Math.floor(this._shake.y);
         }
 
+        this.view.x += this._shake.x;
+        this.view.y += this._shake.y;
+        
         this.displayObject.position.x = -this.view.x;
         this.displayObject.position.y = -this.view.y;
 

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -162,8 +162,8 @@ PIXI.CanvasRenderer.prototype.render = function (root) {
     this.context.globalAlpha = 1;
 
     this.renderSession.currentBlendMode = 0;
-    this.renderSession.shakeX = this.game.camera._shake.x;
-    this.renderSession.shakeY = this.game.camera._shake.y;
+    this.renderSession.shakeX = 0;
+    this.renderSession.shakeY = 0;
 
     this.context.globalCompositeOperation = 'source-over';
 

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -385,8 +385,8 @@ PIXI.WebGLRenderer.prototype.render = function(stage)
         gl.clear(gl.COLOR_BUFFER_BIT);
     }
 
-    this.offset.x = this.game.camera._shake.x;
-    this.offset.y = this.game.camera._shake.y;
+    this.offset.x = 0;
+    this.offset.y = 0;
 
     this.renderDisplayObject(stage, this.projection);
 };


### PR DESCRIPTION
The shake-effect was not working with a filter since Renderers use the _shake attribute from camera.

* is a bug fix (closes #263 )

Removed camera _shake from WebGL/Canvas Renderers. (set to 0)
Added _shake.x and _shake.y to the view in the update method.