### PR TITLE
Fix mspointer (mostly), yay! 🎉

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,16 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Updates
 
+* Added new (internal) helper function `Phaser.DeviceButton#startStop`
+* Added new (internal) function `Phaser.Pointer#processButtonsUpDown` and changed behavior of `Phaser.Pointer#updateButtons`, `Phaser.Pointer#processButtonsUp` and `Phaser.Pointer#processButtonsDown`
+
 ### Bug Fixes
 
+* Fixed several issues related to `[Phaser.MSPointer](https://photonstorm.github.io/phaser-ce/Phaser.MSPointer)` and pointer events (#293, #250)
+
 ### Thanks
+
+@2called-chaos
 
 ## Version 2.8.5 - 30th August 2017
 

--- a/src/input/DeviceButton.js
+++ b/src/input/DeviceButton.js
@@ -210,6 +210,29 @@ Phaser.DeviceButton.prototype = {
 
     },
 
+    /*
+    * Called automatically by Phaser.Pointer.
+    * Starts or stops button based on condition.
+    *
+    * @method Phaser.DeviceButton#startStop
+    * @protected
+    * @param {boolean} [condition] - The condition that decides between start or stop.
+    * @param {object} [event] - The DOM event that triggered the button change.
+    * @param {number} [value] - The button value. Only get for Gamepads.
+    */
+    startStop: function (condition, event, value) {
+
+        if (condition)
+        {
+            this.start(event, value);
+        }
+        else
+        {
+            this.stop(event, value);
+        }
+
+    },
+
     /**
     * Called automatically by Phaser.SinglePad.
     * 

--- a/src/input/Pointer.js
+++ b/src/input/Pointer.js
@@ -437,51 +437,46 @@ Phaser.Pointer.prototype = {
     },
 
     /**
-    * Called by updateButtons.
+    * Called by processButtonsUpDown.
     *
     * @method Phaser.Pointer#processButtonsDown
     * @private
-    * @param {integer} buttons - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons MouseEvent#buttons} value.
+    * @param {integer} button - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button MouseEvent#button} value.
     * @param {MouseEvent} event - The DOM event.
     */
-    processButtonsDown: function (buttons, event) {
+    processButtonsDown: function (button, event) {
 
         //  Note: These are bitwise checks, not booleans
 
-        if (Phaser.Pointer.LEFT_BUTTON & buttons)
+        if (button === Phaser.Mouse.LEFT_BUTTON)
         {
             this.leftButton.start(event);
         }
 
-        if (Phaser.Pointer.RIGHT_BUTTON & buttons)
+        if (button === Phaser.Mouse.RIGHT_BUTTON)
         {
             this.rightButton.start(event);
         }
 
-        if (Phaser.Pointer.MIDDLE_BUTTON & buttons)
+        if (button === Phaser.Mouse.MIDDLE_BUTTON)
         {
             this.middleButton.start(event);
         }
 
-        if (Phaser.Pointer.BACK_BUTTON & buttons)
+        if (button === Phaser.Mouse.BACK_BUTTON)
         {
             this.backButton.start(event);
         }
 
-        if (Phaser.Pointer.FORWARD_BUTTON & buttons)
+        if (button === Phaser.Mouse.FORWARD_BUTTON)
         {
             this.forwardButton.start(event);
-        }
-
-        if (Phaser.Pointer.ERASER_BUTTON & buttons)
-        {
-            this.eraserButton.start(event);
         }
 
     },
 
     /**
-    * Called by updateButtons.
+    * Called by processButtonsUpDown.
     *
     * @method Phaser.Pointer#processButtonsUp
     * @private
@@ -489,6 +484,8 @@ Phaser.Pointer.prototype = {
     * @param {MouseEvent} event - The DOM event.
     */
     processButtonsUp: function (button, event) {
+
+        //  Note: These are bitwise checks, not booleans
 
         if (button === Phaser.Mouse.LEFT_BUTTON)
         {
@@ -515,9 +512,80 @@ Phaser.Pointer.prototype = {
             this.forwardButton.stop(event);
         }
 
-        if (button === 5)
+    },
+
+    /**
+    * Called by updateButtons.
+    *
+    * @method Phaser.Pointer#processButtonsUpDown
+    * @private
+    * @param {integer} buttons - {@link https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons MouseEvent#buttons} value.
+    * @param {MouseEvent} event - The DOM event.
+    */
+    processButtonsUpDown: function (buttons, event) {
+
+        var down = (event.type.toLowerCase().substr(-4) === 'down');
+        var move = (event.type.toLowerCase().substr(-4) === 'move');
+
+        if (buttons !== undefined)
         {
-            this.eraserButton.stop(event);
+            // On OS X (and other devices with trackpads) you have to press CTRL + the pad to initiate a right-click event.
+            if (down && buttons === 1 && event.ctrlKey)
+            {
+                buttons = 2;
+            }
+
+            // Note: These are bitwise checks, not booleans
+            this.leftButton.startStop(Phaser.Pointer.LEFT_BUTTON & buttons, event);
+            this.rightButton.startStop(Phaser.Pointer.RIGHT_BUTTON & buttons, event);
+            this.middleButton.startStop(Phaser.Pointer.MIDDLE_BUTTON & buttons, event);
+            this.backButton.startStop(Phaser.Pointer.BACK_BUTTON & buttons, event);
+            this.forwardButton.startStop(Phaser.Pointer.FORWARD_BUTTON & buttons, event);
+            this.eraserButton.startStop(Phaser.Pointer.ERASER_BUTTON & buttons, event);
+        }
+        else
+        {
+            // No buttons property (like Safari on OSX when using a trackpad)
+            // Attempt to use event.button property or fallback to default
+            if (event.button !== undefined)
+            {
+                // On OS X (and other devices with trackpads) you have to press CTRL + the pad to initiate a right-click event.
+                if (down && event.ctrlKey && event.button === 0)
+                {
+                    this.rightButton.start(event);
+                }
+                else
+                {
+                    if (down)
+                    {
+                        this.processButtonsDown(event.button, event);
+                    }
+                    else if (!move)
+                    {
+                        this.processButtonsUp(event.button, event);
+                    }
+                }
+            }
+            else
+            {
+                if (down)
+                {
+                    // On OS X (and other devices with trackpads) you have to press CTRL + the pad to initiate a right-click event.
+                    if (event.ctrlKey)
+                    {
+                        this.rightButton.start(event);
+                    }
+                    else
+                    {
+                        this.leftButton.start(event);
+                    }
+                }
+                else
+                {
+                    this.leftButton.stop(event);
+                    this.rightButton.stop(event);
+                }
+            }
         }
 
     },
@@ -533,43 +601,7 @@ Phaser.Pointer.prototype = {
     updateButtons: function (event) {
 
         this.button = event.button;
-
-        var down = (event.type.toLowerCase().substr(-4) === 'down');
-
-        if (event.buttons !== undefined)
-        {
-            if (down)
-            {
-                this.processButtonsDown(event.buttons, event);
-            }
-            else
-            {
-                this.processButtonsUp(event.button, event);
-            }
-        }
-        else
-        {
-            //  No buttons property (like Safari on OSX when using a trackpad)
-            if (down)
-            {
-                this.leftButton.start(event);
-            }
-            else
-            {
-                this.leftButton.stop(event);
-                this.rightButton.stop(event);
-            }
-        }
-
-        //  On OS X (and other devices with trackpads) you have to press CTRL + the pad
-        //  to initiate a right-click event, so we'll check for that here ONLY if
-        //  event.buttons = 1 (i.e. they only have a 1 button mouse or trackpad)
-
-        if (event.buttons === 1 && event.ctrlKey && this.leftButton.isDown)
-        {
-            this.leftButton.stop(event);
-            this.rightButton.start(event);
-        }
+        this.processButtonsUpDown(event.buttons, event);
 
         this.isUp = true;
         this.isDown = false;
@@ -727,7 +759,7 @@ Phaser.Pointer.prototype = {
             this.button = event.button;
         }
 
-        if (fromClick && this.isMouse)
+        if (this.isMouse)
         {
             this.updateButtons(event);
         }


### PR DESCRIPTION
This PR

* changes documentation (sortof)
* adds two new internal functions (in Phaser.Pointer and Phaser.DeviceButton)
* changes internal functions in Phaser.Pointer
* makes this PR obsolete #318
* is a bug fix (closes #250, closes #293)

✓ ~~Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.~~

You can test with this build: https://gs.breitzeit.de/phaser/builds/phaser-fix_mspointer_yay_p340.js

Describe the changes below:

* Added new (internal) helper function `Phaser.DeviceButton#startStop`
  _Mainly to make the already long upDown function shorter, it's not used anywhere else but with \_this\_ coding preference it would add so many lines to the upDown function..._
* Added new (internal) function `Phaser.Pointer#processButtonsUpDown`
  _This basically replaces old *Up and *Down functions but I reused them for legacy handling when there is no buttons(plural) event property_
* The changes will improve mouse button support for browsers that don't support buttons property on mouse/pointer events
  _...which were originally dropped when #processButtonsDown was reworked to use the plural variant opposed to just "button", #processButtonsUp was not updated though). I wasn't sure so I included it but if there is no browser (or we don't care) that doesn't even have a button property (maybe touch devices?) we could omit this: https://github.com/2called-chaos/phaser-ce/blob/52f8ac7c26ebafd49df20add27eed348dbf79218/src/input/Pointer.js#L569-L588_
* Before, ctrl-click handling fired event listeners on left mouse button (it was started and immediately stopped so it was no issue if you checked for isDown in an update function but it fired onDown event handler functions) but now we check beforehand and **only** _start()_ the rightButton.
* Those changes resolve a few state issues but the handling of ctrl-click changed in that it will trigger the rightclick but on pointermove it will update the mouse buttons accordingly (hard to explain)
* There is still an issue with `Phaser.Mouse#onMouseOutGlobal` in that it only stops the left and right buttons **and** will not change the overall pointer state (that is `game.input.activePointer.isDown`), this is a different issue but my changes "fix"/"brake" it for leftclick which worked before but was really just a side effect, see [here for more details](https://github.com/photonstorm/phaser-ce/issues/293#issuecomment-322488492).

I tested it with:
  * Firefox/Chrome on Windows/Mac
  * IE12 (I think, some IE though)