### PR TITLE
add Arcade isPaused boolean to ts definition

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3022,6 +3022,7 @@ declare module Phaser {
             forceX: boolean;
             game: Phaser.Game;
             gravity: Phaser.Point;
+            isPaused: boolean;
             quadTree: Phaser.QuadTree;
             maxObjects: number;
             maxLevels: number;


### PR DESCRIPTION
* changes TypeScript definitions

The phaser.d.ts definition of the game.physics.Arcade class is missing 'isPaused': boolean which is implemented in src/physics/arcade/World.js line 72