### PR TITLE
add Arcade > Emitter blendMode to ts definition

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2844,6 +2844,7 @@ declare module Phaser {
                 autoScale: boolean;
                 angle: number;
                 angularDrag: number;
+                blendMode: PIXI.blendMode;
                 bottom: number;
                 bounce: Phaser.Point;
                 count: {emitted: number; failed: number; totalEmitted: number; totalFailed: number};


### PR DESCRIPTION
* changes TypeScript definitions

The d.ts file is missing the blendMode on module Particles > Arcade > class Emitter; It can be found in particles/arcade/Emitter.js, line 161
