### PR TITLE
this.interpolationFunction call bug fix

### DIFF
--- a/src/tween/TweenData.js
+++ b/src/tween/TweenData.js
@@ -458,7 +458,7 @@ Phaser.TweenData.prototype = {
 
                 if (Array.isArray(end))
                 {
-                    blob[property] = this.interpolationFunction(end, this.value);
+                    blob[property] = this.interpolationFunction.call(this.interpolationContext, end, this.value);
                 }
                 else
                 {


### PR DESCRIPTION
this.interpolationFunction call in generateData function in TweenData.js didn't apply context