### PR TITLE
phaser.d.ts PIXI.blendMode bugfix

### DIFF
--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2844,7 +2844,7 @@ declare module Phaser {
                 autoScale: boolean;
                 angle: number;
                 angularDrag: number;
-                blendMode: PIXI.blendMode;
+                blendMode: PIXI.blendModes;
                 bottom: number;
                 bounce: Phaser.Point;
                 count: {emitted: number; failed: number; totalEmitted: number; totalFailed: number};


### PR DESCRIPTION
Bug fix in phaser.d.ts Particles.Arcade.Emitter.blendMode - type should be PIXI.blendModes, not PIXI.blendMode 