### PR TITLE
Phaser.Color.interpolateColor HSV option

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### New Features
 
+* added color space option (RGB or HSV) in [Phaser.Color.interpolateColor](https://photonstorm.github.io/phaser-ce/Phaser.Color.html#_interpolateColor)
+
 ### Updates
 
 * Removed deprecated Phaser.Events#onRemovedFromWorld.
@@ -350,6 +352,8 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 * Added [Phaser.Plugin: Callbacks](https://photonstorm.github.io/phaser-ce/Phaser.Plugin.html).
 
 ### Thanks
+
+@samid737
 
 ## Version 2.8.7 - 12th September 2017
 

--- a/src/utils/Color.js
+++ b/src/utils/Color.js
@@ -798,22 +798,64 @@ Phaser.Color = {
     * @param {number} color2 - The second color value.
     * @param {number} steps - The number of steps to run the interpolation over.
     * @param {number} currentStep - The currentStep value. If the interpolation will take 100 steps, a currentStep value of 50 would be half-way between the two.
+    * @param {number} [colorSpace=0] - The color space to interpolate in. 0=RGB , 1=HSV.
     * @param {number} alpha - The alpha of the returned color.
     * @returns {number} The interpolated color value.
     */
-    interpolateColor: function (color1, color2, steps, currentStep, alpha) {
-
+    interpolateColor: function (color1, color2, steps, currentStep, colorSpace,alpha) {
+        
         if (alpha === undefined) { alpha = 255; }
-
+        if (colorSpace === undefined) { colorSpace = 0; }
+        
         var src1 = Phaser.Color.getRGB(color1);
         var src2 = Phaser.Color.getRGB(color2);
-        var r = (((src2.red - src1.red) * currentStep) / steps) + src1.red;
-        var g = (((src2.green - src1.green) * currentStep) / steps) + src1.green;
-        var b = (((src2.blue - src1.blue) * currentStep) / steps) + src1.blue;
+        
+        if(colorSpace == 0)
+        {
+            var r = (((src2.red - src1.red) * currentStep) / steps) + src1.red;
+            var g = (((src2.green - src1.green) * currentStep) / steps) + src1.green;
+            var b = (((src2.blue - src1.blue) * currentStep) / steps) + src1.blue;
+        }
+
+        if(colorSpace == 1)
+        {
+            var hsv1 = Phaser.Color.RGBtoHSV(src1.r,src1.g,src1.b);
+            var hsv2 = Phaser.Color.RGBtoHSV(src2.r,src2.g,src2.b);
+            var dh = hsv2.h - hsv1.h;
+            var h;
+
+            if (hsv1.h > hsv2.h)
+            {
+                var h3 = hsv2.h;
+                hsv2.h = hsv1.h;
+                hsv1.h = h3;
+                dh = -dh;
+                currentStep = steps - currentStep;
+            }
+
+            if (dh > 0.5)
+            {
+                hsv1.h = hsv1.h + 1; 
+                h =  (((hsv2.h-hsv1.h) * currentStep / steps) + hsv1.h)%1;
+            }
+            
+            if (dh <= 0.5)
+            {
+                h = ((hsv2.h-hsv1.h) * currentStep / steps) + hsv1.h;
+            }
+            
+            var s = (((hsv2.s - hsv1.s) * currentStep) / steps) + hsv1.s;
+            var v = (((hsv2.v - hsv1.v) * currentStep) / steps) + hsv1.v;
+
+            var rgb = Phaser.Color.HSVtoRGB(h,s,v,rgb);
+            var r = rgb.r;
+            var g = rgb.g;
+            var b = rgb.b;             
+        }
 
         return Phaser.Color.getColor32(alpha, r, g, b);
 
-    },
+        },
 
     /**
     * Interpolates the two given colours based on the supplied step and currentStep properties.

--- a/src/utils/Color.js
+++ b/src/utils/Color.js
@@ -810,14 +810,14 @@ Phaser.Color = {
         var src1 = Phaser.Color.getRGB(color1);
         var src2 = Phaser.Color.getRGB(color2);
         
-        if(colorSpace == 0)
+        if(colorSpace === 0)
         {
             var r = (((src2.red - src1.red) * currentStep) / steps) + src1.red;
             var g = (((src2.green - src1.green) * currentStep) / steps) + src1.green;
             var b = (((src2.blue - src1.blue) * currentStep) / steps) + src1.blue;
         }
 
-        if(colorSpace == 1)
+        if(colorSpace === 1)
         {
             var hsv1 = Phaser.Color.RGBtoHSV(src1.r,src1.g,src1.b);
             var hsv2 = Phaser.Color.RGBtoHSV(src2.r,src2.g,src2.b);


### PR DESCRIPTION
* changes the public-facing API

Describe the changes below:

I have A function for interpolating in HSV ([source](http://www.alanzucconi.com/2016/01/06/colour-interpolation/2/)) in one of my codepens, figured why not add it as a feature...

* added color space option (RGB or HSV) in [Phaser.Color.interpolateColor](https://photonstorm.github.io/phaser-ce/Phaser.Color.html#_interpolateColor). RGB or HSV. 

The default is RGB space. A seperate function to do this is also possible, but I figured this might be most suitable (let user choose color space).

Hue shift is clockwise  when the angle is exactly 180 degrees. for example:

red (0xff0000) to cyan (0x00ffff) will take the [clockwise](https://user-images.githubusercontent.com/30023855/30649786-7e091f10-9e21-11e7-8eea-4c1439ee5879.png) direction.  0x00feff (0,254,255) goes counterclockwise.

Demo:

https://codepen.io/Samid737/pen/dVMyye

Or:

https://samid737.github.io/interpolateColor/


