### PR TITLE
Improved tiled support

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ## Unreleased
 
+* Tiled polygons and rectangles are now converted into p2 physics bodies when using `Phaser.Physics.P2#convertCollisionObjects`.
+* Tileset-level collision objects created in Tiled are now added to a map's `collision` and 'objects' properties using the layer's name as the key.
+
 ### New Features
 
 ### Updates
@@ -356,7 +359,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@bobhfut, @falquaddoomi, @HaoboZ, @pavle-goloskokovic, @samme
+@bobhfut, @falquaddoomi, @HaoboZ, @pavle-goloskokovic, @samme, @masondesu
 
 ## Version 2.8.7 - 12th September 2017
 

--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -1662,7 +1662,7 @@ Phaser.Physics.P2.prototype = {
             else if (object.rectangle)
             {
                 var body = this.createBody(object.x, object.y, 0, addToWorld);
-                body.addRectangle(object.width, object.height, object.width / 2, object.height / 2)
+                body.addRectangle(object.width, object.height, object.width / 2, object.height / 2);
             }
 
             // ellipse could be added here, but Tiled ellipses use height/width instead of radius

--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -1650,8 +1650,9 @@ Phaser.Physics.P2.prototype = {
             // polyline: json.layers[i].objects[v].polyline
 
             var object = map.collision[layer][i];
+            var shapeData = object.polyline || object.polygon;
 
-            var body = this.createBody(object.x, object.y, 0, addToWorld, {}, object.polyline);
+            var body = this.createBody(object.x, object.y, 0, addToWorld, {}, shapeData);
 
             if (body)
             {

--- a/src/physics/p2/World.js
+++ b/src/physics/p2/World.js
@@ -1623,8 +1623,8 @@ Phaser.Physics.P2.prototype = {
     },
 
     /**
-    * Converts all of the polylines objects inside a Tiled ObjectGroup into physics bodies that are added to the world.
-    * Note that the polylines must be created in such a way that they can withstand polygon decomposition.
+    * Converts all of the polyline, polygon, and rectangle objects inside a Tiled ObjectGroup into physics bodies that are added to the world.
+    * Note that the polylines and polygons must be created in such a way that they can withstand polygon decomposition.
     *
     * @method Phaser.Physics.P2#convertCollisionObjects
     * @param {Phaser.Tilemap} map - The Tilemap to get the map data from.
@@ -1652,7 +1652,21 @@ Phaser.Physics.P2.prototype = {
             var object = map.collision[layer][i];
             var shapeData = object.polyline || object.polygon;
 
-            var body = this.createBody(object.x, object.y, 0, addToWorld, {}, shapeData);
+            // polyline/polygon shape data present
+            if (shapeData)
+            {
+                var body = this.createBody(object.x, object.y, 0, addToWorld, {}, shapeData);
+            }
+
+            // tilemap parser sets rectangle=true when parsing object groups
+            else if (object.rectangle)
+            {
+                var body = this.createBody(object.x, object.y, 0, addToWorld);
+                body.addRectangle(object.width, object.height, object.width / 2, object.height / 2)
+            }
+
+            // ellipse could be added here, but Tiled ellipses use height/width instead of radius
+            // (to support oblong ellipses), which p2 doesn't currently support.
 
             if (body)
             {

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -177,6 +177,144 @@ Phaser.TilemapParser = {
 
     },
 
+
+    /**
+    * Parses an object group in Tiled JSON files. Object groups can be found in both layers and tilesets. Called internally in parseTiledJSON.
+    * @method Phaser.TilemapParser.parseObjectGroup
+    * @param {object} objectGroup - A JSON object group.
+    * @param {object} objectsCollection - An object into which new array of Tiled map objects will be added.
+    * @param {object} collisionCollection - An object into which new array of collision objects will be added. Currently only polylines are added.
+    * @param {string} [nameKey=objectGroup.name] - Key under which to store objects in collisions in objectsCollection and collisionCollection
+    * @param {object} [relativePosition={x: 0, y: 0}] - Coordinates the object group's positionis relative to.
+    * @return {object} A object literal containing the objectsCollection and collisionCollection
+    */
+    parseObjectGroup: function(objectGroup, objectsCollection, collisionCollection, nameKey, relativePosition){
+        var nameKey = nameKey || objectGroup.name
+        var relativePosition = relativePosition || {x: 0, y: 0}
+
+        if (!nameKey) {
+            console.warn("No name found for objectGroup", objectGroup);
+        }
+        if (relativePosition.x === undefined || relativePosition.y === undefined) {
+            console.warn("Malformed xy properties in relativePosition", relativePosition);
+        }
+
+        objectsCollection[nameKey] = objectsCollection[nameKey] || [];
+        collisionCollection[nameKey] = collisionCollection[nameKey] || [];
+
+        for (var v = 0, len = objectGroup.objects.length; v < len; v++)
+        {
+            //  Object Tiles
+            if (objectGroup.objects[v].gid)
+            {
+                var object = {
+
+                    gid: objectGroup.objects[v].gid,
+                    name: objectGroup.objects[v].name,
+                    type: objectGroup.objects[v].hasOwnProperty("type") ? objectGroup.objects[v].type : "",
+                    x: objectGroup.objects[v].x + relativePosition.x,
+                    y: objectGroup.objects[v].y + relativePosition.y,
+                    width: objectGroup.objects[v].width,
+                    height: objectGroup.objects[v].height,
+                    visible: objectGroup.objects[v].visible,
+                    properties: objectGroup.objects[v].properties
+
+                };
+
+                if (objectGroup.objects[v].rotation)
+                {
+                    object.rotation = objectGroup.objects[v].rotation;
+                }
+
+                objectsCollection[nameKey].push(object);
+            }
+            else if (objectGroup.objects[v].polyline)
+            {
+                var object = {
+
+                    name: objectGroup.objects[v].name,
+                    type: objectGroup.objects[v].type,
+                    x: objectGroup.objects[v].x + relativePosition.x,
+                    y: objectGroup.objects[v].y + relativePosition.y,
+                    width: objectGroup.objects[v].width,
+                    height: objectGroup.objects[v].height,
+                    visible: objectGroup.objects[v].visible,
+                    properties: objectGroup.objects[v].properties
+
+                };
+
+                if (objectGroup.objects[v].rotation)
+                {
+                    object.rotation = objectGroup.objects[v].rotation;
+                }
+
+                object.polyline = [];
+
+                //  Parse the polyline into an array
+                for (var p = 0; p < objectGroup.objects[v].polyline.length; p++)
+                {
+                    object.polyline.push([objectGroup.objects[v].polyline[p].x, objectGroup.objects[v].polyline[p].y]);
+                }
+
+
+                collisionCollection[nameKey].push(object);
+                objectsCollection[nameKey].push(object);
+            }
+            // polygon
+            else if (objectGroup.objects[v].polygon)
+            {
+                var object = slice(objectGroup.objects[v], ['name', 'type', 'x', 'y', 'visible', 'rotation', 'properties']);
+
+                //  Parse the polygon into an array
+                object.polygon = [];
+
+                for (var p = 0; p < objectGroup.objects[v].polygon.length; p++)
+                {
+                    object.polygon.push([objectGroup.objects[v].polygon[p].x, objectGroup.objects[v].polygon[p].y]);
+                }
+
+                collisionCollection[nameKey].push(object);
+                objectsCollection[nameKey].push(object);
+
+            }
+            // ellipse
+            else if (objectGroup.objects[v].ellipse)
+            {
+                var object = slice(objectGroup.objects[v], ['name', 'type', 'ellipse', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
+                objectsCollection[nameKey].push(object);
+            }
+            // otherwise it's a rectangle
+            else
+            {
+                var object = slice(objectGroup.objects[v], ['name', 'type', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
+                object.rectangle = true;
+                objectsCollection[nameKey].push(object);
+            }
+        }
+
+        function slice (obj, fields) {
+
+            var sliced = {};
+
+            for (var k in fields)
+            {
+                var key = fields[k];
+
+                if (typeof obj[key] !== 'undefined')
+                {
+                    sliced[key] = obj[key];
+                }
+            }
+
+            return sliced;
+        }
+
+        return {
+            objectsCollection: objectsCollection,
+            collisionCollection: collisionCollection
+        }
+    },
+
     /**
     * Parses a Tiled JSON file into valid map data.
     * @method Phaser.TilemapParser.parseTiledJSON
@@ -499,23 +637,6 @@ Phaser.TilemapParser = {
         var objects = {};
         var collision = {};
 
-        function slice (obj, fields) {
-
-            var sliced = {};
-
-            for (var k in fields)
-            {
-                var key = fields[k];
-
-                if (typeof obj[key] !== 'undefined')
-                {
-                    sliced[key] = obj[key];
-                }
-            }
-
-            return sliced;
-        }
-
         for (var i = 0; i < json.layers.length; i++)
         {
             if (json.layers[i].type !== 'objectgroup')
@@ -523,98 +644,8 @@ Phaser.TilemapParser = {
                 continue;
             }
 
-            var curo = json.layers[i];
-
-            objects[curo.name] = [];
-            collision[curo.name] = [];
-
-            for (var v = 0, len = curo.objects.length; v < len; v++)
-            {
-                //  Object Tiles
-                if (curo.objects[v].gid)
-                {
-                    var object = {
-
-                        gid: curo.objects[v].gid,
-                        name: curo.objects[v].name,
-                        type: curo.objects[v].hasOwnProperty("type") ? curo.objects[v].type : "",
-                        x: curo.objects[v].x,
-                        y: curo.objects[v].y,
-                        width: curo.objects[v].width,
-                        height: curo.objects[v].height,
-                        visible: curo.objects[v].visible,
-                        properties: curo.objects[v].properties
-
-                    };
-
-                    if (curo.objects[v].rotation)
-                    {
-                        object.rotation = curo.objects[v].rotation;
-                    }
-
-                    objects[curo.name].push(object);
-                }
-                else if (curo.objects[v].polyline)
-                {
-                    var object = {
-
-                        name: curo.objects[v].name,
-                        type: curo.objects[v].type,
-                        x: curo.objects[v].x,
-                        y: curo.objects[v].y,
-                        width: curo.objects[v].width,
-                        height: curo.objects[v].height,
-                        visible: curo.objects[v].visible,
-                        properties: curo.objects[v].properties
-
-                    };
-
-                    if (curo.objects[v].rotation)
-                    {
-                        object.rotation = curo.objects[v].rotation;
-                    }
-
-                    object.polyline = [];
-
-                    //  Parse the polyline into an array
-                    for (var p = 0; p < curo.objects[v].polyline.length; p++)
-                    {
-                        object.polyline.push([ curo.objects[v].polyline[p].x, curo.objects[v].polyline[p].y ]);
-                    }
-
-                    collision[curo.name].push(object);
-                    objects[curo.name].push(object);
-                }
-                // polygon
-                else if (curo.objects[v].polygon)
-                {
-                    var object = slice(curo.objects[v], ['name', 'type', 'x', 'y', 'visible', 'rotation', 'properties']);
-
-                    //  Parse the polygon into an array
-                    object.polygon = [];
-
-                    for (var p = 0; p < curo.objects[v].polygon.length; p++)
-                    {
-                        object.polygon.push([curo.objects[v].polygon[p].x, curo.objects[v].polygon[p].y]);
-                    }
-
-                    objects[curo.name].push(object);
-
-                }
-                // ellipse
-                else if (curo.objects[v].ellipse)
-                {
-                    var object = slice(curo.objects[v], ['name', 'type', 'ellipse', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
-                    objects[curo.name].push(object);
-                }
-                // otherwise it's a rectangle
-                else
-                {
-                    var object = slice(curo.objects[v], ['name', 'type', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
-                    object.rectangle = true;
-                    objects[curo.name].push(object);
-                }
-            }
+            var objectGroup = json.layers[i];
+            this.parseObjectGroup(objectGroup, objects, collision)
         }
 
         map.objects = objects;

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -185,7 +185,7 @@ Phaser.TilemapParser = {
     * @param {object} objectsCollection - An object into which new array of Tiled map objects will be added.
     * @param {object} collisionCollection - An object into which new array of collision objects will be added. Currently only polylines are added.
     * @param {string} [nameKey=objectGroup.name] - Key under which to store objects in collisions in objectsCollection and collisionCollection
-    * @param {object} [relativePosition={x: 0, y: 0}] - Coordinates the object group's positionis relative to.
+    * @param {object} [relativePosition={x: 0, y: 0}] - Coordinates the object group's position is relative to.
     * @return {object} A object literal containing the objectsCollection and collisionCollection
     */
     parseObjectGroup: function(objectGroup, objectsCollection, collisionCollection, nameKey, relativePosition){
@@ -265,6 +265,9 @@ Phaser.TilemapParser = {
             {
                 var object = slice(objectGroup.objects[v], ['name', 'type', 'x', 'y', 'visible', 'rotation', 'properties']);
 
+                object.x += relativePosition.x
+                object.y += relativePosition.y
+
                 //  Parse the polygon into an array
                 object.polygon = [];
 
@@ -281,13 +284,21 @@ Phaser.TilemapParser = {
             else if (objectGroup.objects[v].ellipse)
             {
                 var object = slice(objectGroup.objects[v], ['name', 'type', 'ellipse', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
+                object.x += relativePosition.x;
+                object.y += relativePosition.y;
+
+                collisionCollection[nameKey].push(object);
                 objectsCollection[nameKey].push(object);
             }
             // otherwise it's a rectangle
             else
             {
                 var object = slice(objectGroup.objects[v], ['name', 'type', 'x', 'y', 'width', 'height', 'visible', 'rotation', 'properties']);
+                object.x += relativePosition.x;
+                object.y += relativePosition.y;
+
                 object.rectangle = true;
+                collisionCollection[nameKey].push(object);
                 objectsCollection[nameKey].push(object);
             }
         }
@@ -721,7 +732,7 @@ Phaser.TilemapParser = {
         for (var i = 0; i < map.layers.length; i++)
         {
             layer = map.layers[i];
-
+            collision[layer.name] = []
             set = null;
 
             // rows of tiles

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -189,8 +189,8 @@ Phaser.TilemapParser = {
     * @return {object} A object literal containing the objectsCollection and collisionCollection
     */
     parseObjectGroup: function(objectGroup, objectsCollection, collisionCollection, nameKey, relativePosition){
-        var nameKey = nameKey || objectGroup.name
-        var relativePosition = relativePosition || {x: 0, y: 0}
+        var nameKey = nameKey || objectGroup.name;
+        var relativePosition = relativePosition || {x: 0, y: 0};
 
         if (!nameKey) {
             console.warn("No name found for objectGroup", objectGroup);
@@ -323,7 +323,7 @@ Phaser.TilemapParser = {
         return {
             objectsCollection: objectsCollection,
             collisionCollection: collisionCollection
-        }
+        };
     },
 
     /**
@@ -668,7 +668,7 @@ Phaser.TilemapParser = {
             }
 
             var objectGroup = json.layers[i];
-            this.parseObjectGroup(objectGroup, objects, collision)
+            this.parseObjectGroup(objectGroup, objects, collision);
         }
 
         map.objects = objects;
@@ -732,7 +732,7 @@ Phaser.TilemapParser = {
         for (var i = 0; i < map.layers.length; i++)
         {
             layer = map.layers[i];
-            collision[layer.name] = []
+            collision[layer.name] = [];
             set = null;
 
             // rows of tiles

--- a/src/tilemap/TilemapParser.js
+++ b/src/tilemap/TilemapParser.js
@@ -571,6 +571,7 @@ Phaser.TilemapParser = {
 
         //  Tilesets & Image Collections
         var tilesets = [];
+        var tilesetGroupObjects = {};
         var imagecollections = [];
         var lastSet = null;
 
@@ -614,6 +615,17 @@ Phaser.TilemapParser = {
             else
             {
                 throw new Error('Tileset ' + set.name + ' has no `image` or `tiles` property.');
+            }
+
+            // build a temporary object for objectgroups found in the tileset's tiles
+            for (var ti in set.tiles)
+            {
+                var objectGroup = set.tiles[ti].objectgroup
+                if (!objectGroup)
+                {
+                    continue;
+                }
+                tilesetGroupObjects[parseInt(ti) + set.firstgid] = objectGroup;
             }
 
             //  We've got a new Tileset, so set the lastgid into the previous one
@@ -738,6 +750,21 @@ Phaser.TilemapParser = {
                     if (set.tileProperties && set.tileProperties[tile.index - set.firstgid])
                     {
                         tile.properties = Phaser.Utils.mixin(set.tileProperties[tile.index - set.firstgid], tile.properties);
+                    }
+
+                    var objectGroup = tilesetGroupObjects[tile.index];
+                    if (objectGroup)
+                    {
+                        // build collisions and objects for objectgroups found in the tileset's tiles
+                        this.parseObjectGroup(
+                            objectGroup,
+                            map.objects,
+                            map.collision,
+                            tile.layer.name,
+                            {
+                                x: tile.worldX + objectGroup.x,
+                                y: tile.worldY + objectGroup.y
+                            });
                     }
 
                 }


### PR DESCRIPTION
This PR

* changes documentation
* changes the public-facing API

Hey, everyone. First off, thanks to everyone who's maintaining and contributing to this repo. It's been really cool to see all of the activity, merged PRs, and closed issues just in the few days that I've been working on this PR.

I'm very new to Phaser, but not new to JS and Tiled. I wrote a Ruby adapter for Tiled's `.tmx` format recently, so I was excited to see that Phaser has support for the format baked in. I noticed a few things that seem to be useful/common workflows in Tiled that weren't yet supported in Phaser. After combing through a number of blog posts, forums messages, and GitHub issues circa 2014-2017, I thought this patch might be useful to other people, as well. This PR attempts to address a couple of the issues:

## Support for Tiled's tileset-level collision objects
Tiled makes it really simple to add a collision shape to an individual tile in a tileset, and will include these shape dimensions in an object group on that tile's gid in the tileset's json.

<img width="1127" alt="screen shot 2017-09-24 at 4 58 43 pm" src="https://user-images.githubusercontent.com/434750/30787195-757473da-a151-11e7-93a8-87aea96aee5c.png">

This editor supports polygons, polylines, ellipses, and rectangles. For a map with a tile layer in which some tiles _always_ have collisions, this makes it easy to establish collision bounds once, rather than manually drawing them in a separate object layer. Unforunately, these object groups are ignored by Phaser.

The fix for this involved parsing object groups found inside of tilesets, which was pretty simple because the logic for this already existed in the `Phaser.TilemapParser.parseTiledJSON` method. I just extracted the bit that parses object groups specifically into its own method and used the existing data formats being used in the map's `collision` and `objects` properties, using the layer's name as the key.

## Support Tiled polygons 
I searched quite a bit into why Phaser only supported Tiled's polylines in object layers, as the data structure of polygon is almost identical, but I couldn't find anything. Surprisingly, by just altering a few lines so that polygons were added to a map's collision object and changing `Phaser.Physics.P2#convertCollisionObjects` to make bodies out of polgyons, it seemed to work just fine. Perhaps there's a performance hit or something I'm missing, but hopefully not. This makes the Tiled workflow much nicer, as closing polylines can be a bit of a pain in Tiled, but polygons are closed for you automatically.

Because the object group parser had to be adjusted for tile layer object groups, this means polygon support now works for both tileset-level polygons _and_ object layer polygons. Cool!

Polygon support only affects p2 physics. This doesn't deal with Arcade physics or Ninja.

## Support for Tiled rectangles
An identical situation as above, but with rectangles. Again, this worked really well with minimal adjustment.

## Example
I took a scrap tilesheet, and added polygons, rectangles, and polylines around the water tiles. The variety is simply for demo purposes; otherwise, rectangles and polygons would be sufficient here. The example is pretty straightforward, but I'm happy to explain the reasoning if anything seems confusing.

[Here's a zip of the html, sprites, and tileset](https://www.dropbox.com/s/iavquqrth9imxbn/masondesu-pr-phaser-example.zip?dl=0)

<img width="332" alt="screen shot 2017-09-24 at 5 55 18 pm" src="https://user-images.githubusercontent.com/434750/30787201-9715f590-a151-11e7-8dd8-3791d6127cd8.png">

I'm 100% happy to rebase this, refactor, write specs, or whatever else y'all deem necessary to land this. Just let me know, and thanks again.
