### PR TITLE
Prevent Phaser.Tilemap#createFromObjects from overriding sprite visibility as set in Tiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 # Change Log
 
 ## Unreleased
+* Prevent `Phaser.Tilemap#createFromObjects` from overriding sprite visibility as set in Tiled.
 
 ### New Features
 

--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -435,9 +435,9 @@ Phaser.Tilemap.prototype = {
                 var sprite = new CustomClass(this.game, parseFloat(obj.x, 10), parseFloat(obj.y, 10), key, frame);
 
                 sprite.name = obj.name;
-                sprite.visible = obj.visible;
                 sprite.autoCull = autoCull;
                 sprite.exists = exists;
+                sprite.visible = obj.visible;
 
                 if (obj.width)
                 {


### PR DESCRIPTION
This PR

* is a bug fix

Currently, setting `visible = true` in an object layer in Tiled doesn't work when calling `createFromObjects`. After digging into why, I realized that `Phaser.Tilemap#createFromObjects` sets `sprite.visible` before setting `sprite.exists`, but `sprite.exists` has a custom setter that overrides the `visible` property (see https://github.com/photonstorm/phaser/blob/v2.4.4/src/gameobjects/components/Core.js#L277). This just reorders the assignments so that visibility is set afterwards. Appears to fix the issue.