### PR TITLE
Removing callback on a tile to null now works as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 # Change Log
 
+## Unreleased
+
+[Phaser.Tilemap#setTileIndexCallback](https://github.com/photonstorm/phaser-ce/blob/master/src/tilemap/Tilemap.js#L798) can now correctly remove a callback by setting it to `null`.
+
 ## Version 2.9.0 - 8th October 2017
 
 The minor version increase is for changes to [Emitter#cursor](https://photonstorm.github.io/phaser-ce/Phaser.Particles.Arcade.Emitter.html#cursor).

--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -801,15 +801,29 @@ Phaser.Tilemap.prototype = {
 
         if (typeof indexes === 'number')
         {
-            //  This may seem a bit wasteful, because it will cause empty array elements to be created, but the look-up cost is much
-            //  less than having to iterate through the callbacks array hunting down tile indexes each frame, so I'll take the small memory hit.
-            this.layers[layer].callbacks[indexes] = { callback: callback, callbackContext: callbackContext };
+            if (callback === null)
+            {
+                delete this.layers[layer].callbacks[indexes];
+            }
+            else
+            {
+                //  This may seem a bit wasteful, because it will cause empty array elements to be created, but the look-up cost is much
+                //  less than having to iterate through the callbacks array hunting down tile indexes each frame, so I'll take the small memory hit.
+                this.layers[layer].callbacks[indexes] = { callback: callback, callbackContext: callbackContext };
+            }
         }
         else
         {
             for (var i = 0, len = indexes.length; i < len; i++)
             {
-                this.layers[layer].callbacks[indexes[i]] = { callback: callback, callbackContext: callbackContext };
+                if (callback === null)
+                {
+                    delete this.layers[layer].callbacks[indexes[i]];
+                }
+                else
+                {
+                    this.layers[layer].callbacks[indexes[i]] = { callback: callback, callbackContext: callbackContext };
+                }
             }
         }
 


### PR DESCRIPTION
This PR is a bug fix.

`Phaser.Tilemap#setTileIndexCallback`'s documentation indicates that callbacks can be removed by passing in null as the callback argument (see https://github.com/photonstorm/phaser/blob/v2.4.4/src/tilemap/Tilemap.js#L751). This removes the callback object as expected.

This was originally opened as https://github.com/photonstorm/phaser-ce/pull/376, but this cleans up the commit log a bit. Thanks!