### PR TITLE
Fixed issue that prevented BitmapText's text to be shown completely.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,11 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 * [Phaser.Tilemap#setTileIndexCallback](https://github.com/photonstorm/phaser-ce/blob/master/src/tilemap/Tilemap.js#L798) now correctly removes a callback when `null` is passed.
 * Fixed [Emitter#counts](https://photonstorm.github.io/phaser-ce/Phaser.Particles.Arcade.Emitter.html#counts) not counting.
 * Fixed missing TypeScript return values (#382).
+* Fixed bug that did not show the last line of text on a BitmapText when the last character was the one that created the need for a newLine (when maxWidth was set).
 
 ### Thanks
 
-@masondesu, @pavle-goloskokovic, @photonstorm, @samme
+@masondesu, @pavle-goloskokovic, @photonstorm, @samme, @andiCR
 
 For changes in previous releases please see the extensive [Change Log](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md).
 

--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -290,7 +290,7 @@ Phaser.BitmapText.prototype.scanLine = function (data, scale, text) {
             if (maxWidth && ((w + c) >= maxWidth) && lastSpace > -1)
             {
                 //  The last space was at "lastSpace" which was "i - lastSpace" characters ago
-                return { width: wrappedWidth || w, text: text.substr(0, i - (i - lastSpace)), end: end, chars: chars };
+                return { width: wrappedWidth || w, text: text.substr(0, i - (i - lastSpace)), end: false, chars: chars };
             }
             else
             {


### PR DESCRIPTION
This PR 
* is a bug fix 

Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.

Describe the changes below:
Fixed issue that ignored a new line if the last character being evaluated on the scanLine function of a BitmapText exceeded the maxWidth of said text. This bug would prevent the last part of a text to be shown, as the scanLine function would think the text has already ended, even if it was by itself cutting out the last part.