### PR TITLE
Fix grammar in invalid state message

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,10 +333,11 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Bug Fixes
 
 * Fixed bug that did not show the last line of text on a BitmapText when the last character was the one that created the need for a newLine (when maxWidth was set).
+* Fixed grammar in the error message if an invalid State object is provided to the StateManager.
 
 ### Thanks
 
-@andiCR
+@andiCR, @JamesSkemp
 
 ## Version 2.9.1 - 10th October 2017
 

--- a/src/core/StateManager.js
+++ b/src/core/StateManager.js
@@ -446,7 +446,7 @@ Phaser.StateManager.prototype = {
             }
             else
             {
-                console.warn("Invalid Phaser State object given. Must contain at least a one of the required functions: preload, create, update or render");
+                console.warn("Invalid Phaser State object given. Must contain at least one of the required functions: preload, create, update or render");
                 return false;
             }
         }


### PR DESCRIPTION
This PR 

* changes documentation

Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.

Describe the changes below:
This simply updates the grammar in the error message when the state manager is provided an object that isn't a valid State.