### PR TITLE
Update p2.js typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 * Audio and video are now [touch-unlocked](https://photonstorm.github.io/phaser-ce/Phaser.Device.html#needsTouchUnlock) only via the [touchend](https://developer.mozilla.org/en-US/docs/Web/Events/touchend) event (#92). Previously we used `touchend` for audio on newer Chrome and iOS clients and `touchstart` in all other cases.
 * Tilemap#addTilesetImage, Tilemap#createFromObjects, and Tilemap#createLayer print the map's contents (following the usual warning) in the console if you pass a bad name or identifier.
 * Tileset#addTilesetImage gives a little more information when warning about image dimension mismatches.
+* p2.js typeScript definitions fixes and updates 
 
 ### Bug Fixes
 
@@ -369,7 +370,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@16patsle, @andiCR, @daniel-nth, @JamesSkemp, @martinlindhe, @photonstorm, @rmartone, @samme
+@16patsle, @andiCR, @daniel-nth, @JamesSkemp, @martinlindhe, @photonstorm, @rmartone, @samme, @Nek-
 
 For changes in previous releases please see the extensive [Change Log](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md).
 

--- a/typescript/p2.d.ts
+++ b/typescript/p2.d.ts
@@ -444,16 +444,16 @@ declare module p2 {
 
     }
 
-    export class BodyOptions {
+    export interface BodyOptions {
 
-        mass: number;
-        position: number[];
-        velocity: number[];
-        angle: number;
-        angularVelocity: number;
-        force: number[];
-        angularForce: number;
-        fixedRotation: number;
+        mass?: number;
+        position?: number[];
+        velocity?: number[];
+        angle?: number;
+        angularVelocity?: number;
+        force?: number[];
+        angularForce?: number;
+        fixedRotation?: boolean;
 
     }
 
@@ -646,6 +646,23 @@ declare module p2 {
 
     }
 
+    export interface SharedShapeOptions {
+
+        position?: number[];
+        angle?: number;
+        collisionGroup?: number;
+        collisionResponse?: boolean;
+        collisionMask?: number;
+        sensor?: boolean;
+
+    }
+
+    export interface ShapeOptions extends SharedShapeOptions {
+
+        type?: number;
+
+    }
+
     export class Shape {
 
         static idCounter: number;
@@ -658,7 +675,7 @@ declare module p2 {
         static CAPSULE: number;
         static HEIGHTFIELD: number;
 
-        constructor(type: number);
+        constructor(options?: ShapeOptions);
 
         type: number;
         id: number;


### PR DESCRIPTION
This PR:

* changes TypeScript definitions

The suggested typings comes from the official p2 typings. (from DefinitelyTyped)
I copy/paste the whole typings because they are not compatible with the phaser version.