### PR TITLE
Fix async load complete when state is destroyed

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 * [Phaser.Tween#start](https://photonstorm.github.io/phaser-ce/Phaser.Tween.html#start) no longer tries to start a tween marked for deletion (such as by [Tween#stop](https://photonstorm.github.io/phaser-ce/Phaser.Tween.html#stop)). Instead it prints a warning to the console (#401).
 * Fixed tweens not repeating when [Tween#start](https://photonstorm.github.io/phaser-ce/Phaser.Tween.html#start) is called after [Tween#repeat](https://photonstorm.github.io/phaser-ce/Phaser.Tween.html#repeat) (#408).
+* Fix async load complete when state is destroyed (#410).
 
 ### Documentation
 
@@ -355,7 +356,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@husengbatute29, @Nek-, @samme
+@husengbatute29, @Nek-, @samme, @clesquir
 
 ## Version 2.9.2 - 9th November 2017
 

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -2052,7 +2052,10 @@ Phaser.Loader.prototype = {
 
         this.onLoadComplete.dispatch();
 
-        this.game.state.loadComplete();
+        //Completes if the state still exists since destroy could have occurred while loading
+        if (this.game.state) {
+            this.game.state.loadComplete();
+        }
 
     },
 


### PR DESCRIPTION
This PR:
* is a bug fix

Avoid raising this following error if state has been destroyed during async loading:
```
Uncaught TypeError: Cannot read property 'loadComplete' of null
    at Phaser.Loader.finishedLoading
    at Phaser.Loader.processLoadQueue
    at Phaser.Loader.asyncComplete
    at Phaser.Loader.fileComplete
    at Image.file.data.onload
```