### PR TITLE
added typescript definitions for sprite.outOfCameraBoundsKill boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## Unreleased
+* Added typescript definitions for Phaser.Sprite.outOfCameraBoundsKill
+Thanks @GrindheadGames
 
 See [README: Change Log: Unreleased](README.md#unreleased).
 

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -26759,6 +26759,11 @@ declare module Phaser {
         outOfBoundsKill: boolean;
 
         /**
+         * If this and the autoCull property are both set to true, then the kill method is called as soon as the Game Object leaves the camera bounds. 
+         */
+        outOfCameraBoundsKill: boolean;
+
+        /**
         * A Game Object is that is pendingDestroy is flagged to have its destroy method called on the next logic update.
         * You can set it directly to allow you to flag an object to be destroyed on its next update.
         * 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4754,6 +4754,7 @@ declare module Phaser {
         offsetX: number;
         offsetY: number;
         outOfBoundsKill: boolean;
+        outOfCameraBoundsKill: boolean;
         pendingDestroy: boolean;
         previousPosition: Phaser.Point;
         previousRotation: number;


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* changes TypeScript definitions

Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.

Describe the changes below:

added typescript definitions for Phaser.Sprite.outOfCameraBoundsKill boolean