### PR TITLE
[bug] Rope.js fixed sequentional setup of optional 'points' argument

### DIFF
--- a/src/gameobjects/Rope.js
+++ b/src/gameobjects/Rope.js
@@ -43,8 +43,7 @@
 */
 Phaser.Rope = function (game, x, y, key, frame, points) {
 
-    this.points = [];
-    this.points = points;
+    this.points = points || [];
     this._hasUpdateAnimation = false;
     this._updateAnimationCallback = null;
     x = x || 0;
@@ -57,8 +56,6 @@ Phaser.Rope = function (game, x, y, key, frame, points) {
     * @readonly
     */
     this.type = Phaser.ROPE;
-
-    this.points = points;
 
     PIXI.DisplayObjectContainer.call(this);
 


### PR DESCRIPTION
Removed mistyped sequence of points property setup from constructor