### PR TITLE
Enabling Gamepad input while game is paused

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1031,6 +1031,7 @@ Phaser.Game.prototype = {
             this.scale.pauseUpdate();
             this.state.pauseUpdate(timeStep);
             this.debug.preUpdate();
+            this.input.pauseUpdate();
         }
 
         this.stage.updateTransform();

--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -715,6 +715,21 @@ Phaser.Input.prototype = {
     },
 
     /**
+     * Update method while paused.
+     *
+     * @method Phaser.Input#pauseUpdate
+     * @private
+     */
+    pauseUpdate: function () {
+
+        if (this.gamepad && this.gamepad.active)
+        {
+            this.gamepad.update();
+        }
+
+    },
+
+    /**
     * Reset all of the Pointers and Input states.
     *
     * The optional `hard` parameter will reset any events or callbacks that may be bound.
@@ -739,11 +754,6 @@ Phaser.Input.prototype = {
         if (this.keyboard)
         {
             this.keyboard.reset(hard);
-        }
-
-        if (this.gamepad)
-        {
-            this.gamepad.reset();
         }
 
         for (var i = 0; i < this.pointers.length; i++)


### PR DESCRIPTION
This PR

* changes the public-facing API

When game is paused, input events from gamepad controllers are not handled.
This prevents any user interaction trough gamepad if game gets paused when opening game menus and basically blocks the game since user can not exit the menu or choose any option if there are no other input methods available (like keyboard, mouse or touch events).

It ruins the players' experience or forces developer to not use gamepads or drastically change game code in order to do so.

This PR enables gamepad controllers to be used while game is paused and solves this issue.
