### PR TITLE
Bug fix for changing smoothing property in WebGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,10 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 * Fixed a false positive in [TweenManager#isTweening](https://photonstorm.github.io/phaser-ce/Phaser.TweenManager.html#isTweening) (#414).
 * Changing smoothing using WebGL now marks the texture as dirty
 
+### Thanks
+
+@Mertank
+
 ## Version 2.9.4 - 20th December 2017
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Bug Fixes
 
 * Fixed a false positive in [TweenManager#isTweening](https://photonstorm.github.io/phaser-ce/Phaser.TweenManager.html#isTweening) (#414).
+* Changing smoothing using WebGL now marks the texture as dirty
 
 ## Version 2.9.4 - 20th December 2017
 

--- a/src/gameobjects/components/Smoothed.js
+++ b/src/gameobjects/components/Smoothed.js
@@ -37,6 +37,7 @@ Phaser.Component.Smoothed.prototype = {
                 if (this.texture)
                 {
                     this.texture.baseTexture.scaleMode = 0;
+                    this.texture.baseTexture.dirty();
                 }
             }
             else
@@ -44,6 +45,7 @@ Phaser.Component.Smoothed.prototype = {
                 if (this.texture)
                 {
                     this.texture.baseTexture.scaleMode = 1;
+                    this.texture.baseTexture.dirty();
                 }
             }
         }


### PR DESCRIPTION
This PR
* is a bug fix

Describe the changes below:

I just came across an issue while using the WebGL renderer.

When updating the 'smoothed' property on a Sprite it did not flag the base texture as dirty. This meant that if you loaded the image as true and then flipped it to false later on it would remain smoothed. WebGL wasn't updating the texture's TEXTURE_MIN_FILTER. 

This now flags the texture as dirty when that property is updated.
  