### PR TITLE
Added texture dirty call to BitmapText for WebGL

### DIFF
--- a/src/gameobjects/BitmapText.js
+++ b/src/gameobjects/BitmapText.js
@@ -707,6 +707,7 @@ Object.defineProperty(Phaser.BitmapText.prototype, 'smoothed', {
         {
             this._data.base.scaleMode = 1;
         }
+        this._data.base.dirty();
 
     }
 


### PR DESCRIPTION
This PR

* is a bug fix

Describe the changes below:

After seeing the forum post in the other PR: https://github.com/photonstorm/phaser-ce/pull/432
I saw that BitmapText manually sets the scaleMode which is why it wasn't working for that user. I've added the dirty call to the part of BitmapText that changes it so that it will fix the problem for that user too.