### PR TITLE
Fixed incorrect TypeScript defintion: Input.pointer to Input.pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 * Fixed a false positive in [TweenManager#isTweening](https://photonstorm.github.io/phaser-ce/Phaser.TweenManager.html#isTweening) (#414).
 * Changing a display object's [smoothed](https://photonstorm.github.io/phaser-ce/Phaser.Sprite.html#smoothed) property now marks the WebGL texture as dirty (#432, #433).
+* TypeScript defintions: Input.pointer to Input.pointers
 
 ### Thanks
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2116,7 +2116,7 @@ declare module Phaser {
         pollLocked: boolean;
         pollRate: number;
         position: Phaser.Point;
-        pointer: Phaser.Pointer[];
+        pointers: Phaser.Pointer[];
         recordLimit: number;
         recordPointerHistory: boolean;
         recordRate: number;


### PR DESCRIPTION
* changes TypeScript definitions

Fixed incorrect TypeScript defintion: Input.pointer to Input.pointers