### PR TITLE
Added a playOnce boolean in order to mark the sound for deletion after the initial play.

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -144,6 +144,12 @@ Phaser.Sound = function (game, key, volume, loop, connect) {
     this.allowMultiple = false;
 
     /**
+    * @property {boolean} playOnce - Marks the Sound for deletion from SoundManager._sounds after playing once - useful for playing several identical sounds overlapping without flooding the sound channel
+    * @default
+    */
+    this.playOnce = false;
+
+    /**
     * @property {boolean} usingWebAudio - true if this sound is being played with Web Audio.
     * @readonly
     */
@@ -786,6 +792,14 @@ Phaser.Sound.prototype = {
                     this.pendingPlayback = true;
                 }
             }
+        }
+
+        if (this.playOnce) {
+            if (this.loop) {
+                console.warn('Phaser.Sound.play: audio clip ' + this.name + ' cannot be deleted while looping.');
+            }
+            
+            this._markedToDelete = true;
         }
 
         return this;

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4673,6 +4673,7 @@ declare module Phaser {
         pausedPosition: number;
         pausedTime: number;
         pendingPlayback: boolean;
+        playOnce: boolean;
         position: number;
         startTime: number;
         stopTime: number;


### PR DESCRIPTION
This PR

* changes the public-facing API

This property addition will allow developers to flag a sound for deletion after it is played once.  This is a simple method for avoiding creating new `_sounds` entries for sounds that are intended to just be played once and done.
