### PR TITLE
Fix separate circle physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,13 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 * Phaser.Sound#playOnce flags a sound for deletion after it is played once. This is a simple method for avoiding [adding](https://photonstorm.github.io/phaser-ce/Phaser.SoundManager.html#add) new Sound objects for sounds that are intended to just be played once and done.
 
+### Bug Fixes
+
+* Fixes circles stick to each other using Arcade physics (#451).
+
 ### Thanks
 
-@samme, @wtravO
+@samme, @wtravO, @mmacvicar
 
 ## Version 2.10.0 - 18 January 2018
 

--- a/src/physics/arcade/World.js
+++ b/src/physics/arcade/World.js
@@ -1270,12 +1270,12 @@ Phaser.Physics.Arcade.prototype = {
         // This is done to eliminate the vertical component of the velocity
         var v1 = {
             x: body1.velocity.x * Math.cos(angleCollision) + body1.velocity.y * Math.sin(angleCollision),
-            y: body1.velocity.x * Math.sin(angleCollision) - body1.velocity.y * Math.cos(angleCollision)
+            y: -body1.velocity.x * Math.sin(angleCollision) + body1.velocity.y * Math.cos(angleCollision)
         };
 
         var v2 = {
             x: body2.velocity.x * Math.cos(angleCollision) + body2.velocity.y * Math.sin(angleCollision),
-            y: body2.velocity.x * Math.sin(angleCollision) - body2.velocity.y * Math.cos(angleCollision)
+            y: -body2.velocity.x * Math.sin(angleCollision) + body2.velocity.y * Math.cos(angleCollision)
         };
 
         // We expect the new velocity after impact


### PR DESCRIPTION
This PR is a bug fix (closes #451)

The basis oriented along the direction of impact and the tangential speed is not converted properly during calculations. This change makes sure the same basis is used when converting back and forth. 