### PR TITLE
Fix spelling error in API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Bug Fixes
 
 * Fixes circles stick to each other using Arcade physics (#451).
+* Fixes spelling error in API documentation.
 
 ### Thanks
 

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -17,7 +17,7 @@
 * For example a Sprite has a `game` property, allowing you to talk to the various parts
 * of Phaser directly, without having to look after your own references.
 *
-* In it's most simplest form, a Phaser game can be created by providing the arguments
+* In its most simplest form, a Phaser game can be created by providing the arguments
 * to the constructor:
 *
 * ```javascript


### PR DESCRIPTION
- [x] This PR (choose one or more, ✏️ delete others)

* changes documentation

- [x] Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.

- [x] Describe the changes below:

Fixes a spelling error in the API documentation that appears here: 
https://photonstorm.github.io/phaser-ce/Phaser.Game.html#Game