### PR TITLE
Fixed TS definition for bitmapText in GameObjectCreator (closes #460)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,10 +337,11 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Bug Fixes
 
 * Fixes circles stick to each other using Arcade physics (#451).
+* Fixes TS definition for bitmapText in GameObjectCreator (#460).
 
 ### Thanks
 
-@samme, @wtravO, @mmacvicar
+@samme, @wtravO, @mmacvicar, @netdream
 
 ## Version 2.10.0 - 18 January 2018
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1621,7 +1621,7 @@ declare module Phaser {
         audio(key: string, volume?: number, loop?: boolean, connect?: boolean): Phaser.Sound;
         audioSprite(key: string): Phaser.AudioSprite;
         bitmapData(width?: number, height?: number, key?: string, addToCache?: boolean): Phaser.BitmapData;
-        bitmapText(x: number, y: number, font: string, text?: string, size?: number, group?: Phaser.Group | Phaser.Stage): Phaser.BitmapText;
+        bitmapText(x: number, y: number, font: string, text?: string, size?: number, align?: string): Phaser.BitmapText;
         button(x?: number, y?: number, key?: string, callback?: Function, callbackContext?: any, overFrame?: any, outFrame?: any, downFrame?: any, upFrame?: any, group?: Phaser.Group | Phaser.Stage): Phaser.Button;
         emitter(x?: number, y?: number, maxParticles?: number): Phaser.Particles.Arcade.Emitter;
         existing(object: any): any;


### PR DESCRIPTION
This PR is a bug fix (closes #460 )

It changes TypeScript definition for bitmapText in GameObjectCreator