### PR TITLE
Fix audiosprite looping issue after paused

### DIFF
--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -879,14 +879,16 @@ Phaser.Sound.prototype = {
                     this._sound.connect(this.gainNode);
                 }
 
-                if (this.loop)
+                if (this.currentMarker === '')
                 {
-                    this._sound.loop = true;
-                }
-
-                if (!this.loop && this.currentMarker === '')
-                {
-                    this._sound.onended = this.onEndedHandler.bind(this);
+                    if (this.loop)
+                    {
+                        this._sound.loop = true;
+                    }
+                    else
+                    {
+                        this._sound.onended = this.onEndedHandler.bind(this);
+                    }
                 }
 
                 var duration = this.duration - (this.pausedPosition / 1000);
@@ -907,7 +909,14 @@ Phaser.Sound.prototype = {
                         }
                         else
                         {
-                            this._sound.start(0, p);
+                            if (this.currentMarker === '')
+                            {
+                                this._sound.start(0, p);
+                            }
+                            else
+                            {
+                                this._sound.start(0, p, duration);
+                            }
                         }
                     }
                     else


### PR DESCRIPTION
This PR is a bug fix for issue #323 

I have modified Phaser.Sound#resume:
1. setting Phaser.Sound#_sound.loop to true only when ```currentMarker === ''```
2. Phaser.Sound#_sound.start filled with duration as parameter if ```currentMarker === ''```

Here if the modified version:
https://codepen.io/squaresun/pen/GQjLYo

I have tested on Safari (Mac OS and iOS) and Desktop Chrome but I don't confirm if this PR is safe enough.