### PR TITLE
Fix ScaleManager reference to the parent element

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 # Change Log
 
 ## Unreleased
+* Fix ScaleManager reference to the parent element. The canvas now correctly scales inside a container div if using relative values for width/height on Phaser.Game constructor.
 
 ### New Features
 

--- a/src/core/ScaleManager.js
+++ b/src/core/ScaleManager.js
@@ -1433,7 +1433,7 @@ Phaser.ScaleManager.prototype = {
             }
             else if (scaleMode === Phaser.ScaleManager.SHOW_ALL)
             {
-                if (!this.isFullScreen && this.boundingParent &&
+                if (!this.isFullScreen && this.parentNode &&
                     this.compatibility.canExpandParent)
                 {
                     // Try to expand parent out, but choosing maximizing dimensions.
@@ -1495,7 +1495,7 @@ Phaser.ScaleManager.prototype = {
     getParentBounds: function (target) {
 
         var bounds = target || new Phaser.Rectangle();
-        var parentNode = this.boundingParent;
+        var parentNode = this.parentNode;
         var visualBounds = this.dom.visualBounds;
         var layoutBounds = this.dom.layoutBounds;
 


### PR DESCRIPTION
This PR
* is a bug fix

Live Example: https://codepen.io/pantoninho/pen/rJyjxb 

Describe the changes below:

ScaleManager references `this.boundingParent` to calculate the initial canvas size, but this property does not hold any value.. I suppose it was left-over code from previous commits.

There were multiple reports in the original phaser repo that may be related to this issue:
photonstorm/phaser#2592
photonstorm/phaser#2458
photonstorm/phaser#2556

Replacing `this.boundingParent` references to `this.parentNode` solves the problem and everything works as expected.

The grunt task is not re-building the custom builds, is it supposed to?