### PR TITLE
Customize character string used to calculate text width and height

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 # Change Log
 
+## Unreleased
+
+* Changes added to customize the character string that is used to calculate the text width and height. 
+
 ## Version 2.10.3 - 21st March 2018
 
 ### Bug Fixes
@@ -336,7 +340,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@KIVassilev, @photonstorm, @samme
+@KIVassilev, @photonstorm, @samme, @hardylr
 
 For changes in previous releases please see the extensive [Change Log](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md).
 

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -151,6 +151,11 @@ Phaser.Text = function (game, x, y, text, style) {
     */
     this.characterLimitSuffix = '';
 
+    /** The text to use to measure the font width and height
+    * @property {string} _measureText
+    */
+    this._measureText = '|MÉq';
+
     /**
      * @property {number} _res - Internal canvas resolution var.
      * @private
@@ -1547,6 +1552,7 @@ Phaser.Text.prototype._renderCanvas = function (renderSession) {
 Phaser.Text.prototype.determineFontProperties = function (fontStyle) {
 
     var properties = Phaser.Text.fontPropertiesCache[fontStyle];
+    var measureText = this.measureText || '|MÉq';
 
     if (!properties)
     {
@@ -1556,9 +1562,9 @@ Phaser.Text.prototype.determineFontProperties = function (fontStyle) {
         var context = Phaser.Text.fontPropertiesContext;
 
         context.font = fontStyle;
-
-        var width = Math.ceil(context.measureText('|MÉq').width);
-        var baseline = Math.ceil(context.measureText('|MÉq').width);
+        
+        var width = Math.ceil(context.measureText(measureText).width); 
+        var baseline = Math.ceil(context.measureText(measureText).width);
         var height = 2 * baseline;
 
         baseline = baseline * 1.4 | 0;
@@ -1572,8 +1578,8 @@ Phaser.Text.prototype.determineFontProperties = function (fontStyle) {
         context.font = fontStyle;
 
         context.textBaseline = 'alphabetic';
-        context.fillStyle = '#000';
-        context.fillText('|MÉq', 0, baseline);
+        context.fillStyle = '#000';        
+        context.fillText(measureText, 0, baseline);
 
         if (!context.getImageData(0, 0, width, height))
         {
@@ -2334,6 +2340,26 @@ Object.defineProperty(Phaser.Text.prototype, 'height', {
     }
 
 });
+
+/**
+* The text used to measure the font's width and height
+* @name Phaser.Text#measureText
+* @property {string} measureText - Characters to use to measure the width and height of the font. default '|MÉq'
+*/
+Object.defineProperty(Phaser.Text.prototype, 'measureText', {
+
+    get: function() {
+
+        return this._measureText;
+    },
+
+    set: function(value) {
+
+        this._measureText = value;
+        this.updateText();        
+    }
+});
+
 
 Phaser.Text.fontPropertiesCache = {};
 


### PR DESCRIPTION
This PR changes the public-facing API

Changes added to customize the character string that is used to calculate the text width and height. 
This was needed because the character sizing was calculated incorrectly and characters were being cut off when using localized font. (example: Thai "บิ๊กวิน")
