### PR TITLE
Ellipse random() area calculation for points fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Fixed Ellipse random point area calculation (#522).
+
 See [README: Change Log: Unreleased](README.md#unreleased).
 
 ## Version 2.10.3 - 21st March 2018

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ## Unreleased
 
+* Fixed Ellipse random point area calculation (#522).
+
 ### TypeScript definitions
 
 * Corrected 2 TypeScript definitions of p2.
@@ -342,7 +344,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@KIVassilev, @photonstorm, @samme
+@KIVassilev, @photonstorm, @samme, @budda
 
 For changes in previous releases please see the extensive [Change Log](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md).
 

--- a/src/geom/Ellipse.js
+++ b/src/geom/Ellipse.js
@@ -167,8 +167,8 @@ Phaser.Ellipse.prototype = {
         out.x = Math.sqrt(r) * Math.cos(p);
         out.y = Math.sqrt(r) * Math.sin(p);
 
-        out.x = this.x + (out.x * this.width / 2.0);
-        out.y = this.y + (out.y * this.height / 2.0);
+        out.x = this.x + (out.x * this.width);
+        out.y = this.y + (out.y * this.height);
 
         return out;
 


### PR DESCRIPTION
Ellipse random points are being restricted to a smaller central area of the ellipse with a large padding between the points and the ellipse circumference.

This PR

* is a bug fix

Describe the changes below:

Phaser.Ellipse.random() returned a point from within a smaller Ellipse than what was defined due to the width & height being divided by 2. Removed the division from both lines.

See screenshots attached to issue #522 