### PR TITLE
Corrected doc typo re: state property from Issue #521

### DIFF
--- a/src/core/State.js
+++ b/src/core/State.js
@@ -90,7 +90,7 @@ Phaser.State = function () {
     this.stage = null;
 
     /**
-    * @property {Phaser.StateManager} stage - A reference to the State Manager, which controls state changes.
+    * @property {Phaser.StateManager} state - A reference to the State Manager, which controls state changes.
     */
     this.state = null;
 


### PR DESCRIPTION
This PR 
* changes documentation

Describe the changes below:
There appears to be a typo in State.js as mentioned by Issue #521 . This PR corrects "stage" to "state".
