### PR TITLE
Added Emitter.area to Typescript definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### TypeScript definitions
+Updated the Typescript definitions to include the property 'area' within the Emitter class.
+
+### Thanks
+
+@GrindheadGames
+
 See [README: Change Log: Unreleased](README.md#unreleased).
 
 ## Version 2.10.4 - 3rd May 2018

--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -16899,6 +16899,11 @@ declare module Phaser {
                 constructor(game: Phaser.Game, x?: number, y?: number, maxParticles?: number);
 
 
+                /** 
+                * The area of the emitter. Particles can be randomly generated from anywhere within this rectangle. 
+                */
+                area: Phaser.Rectangle;
+
                 /**
                 * An array of the calculated alpha easing data applied to particles with alphaRates > 0.
                 */

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -2939,6 +2939,7 @@ declare module Phaser {
 
                 constructor(game: Phaser.Game, x?: number, y?: number, maxParticles?: number);
 
+                area: Phaser.Rectangle;
                 alphaData: any[];
                 autoAlpha: boolean;
                 autoScale: boolean;


### PR DESCRIPTION
This PR changes TypeScript definitions.
Updated the Typescript definitions to include the property 'area' within the Emitter class.