### PR TITLE
Change unused GameConfig property canvasId to canvasID

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,16 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 # Change Log
 
+## Unreleased
+
+### Documentation
+
+* Changed [the game configuration object's](https://photonstorm.github.io/phaser-ce/global.html#GameConfig) `canvasID` property name - the previous value, `canvasId`, was not used.
+
+### Thanks
+
+@rydash
+
 ## Version 2.11.0 - 26 June 2018
 
 If you're starting or stopping input handlers manually, you'll have to make some simple changes to your code.

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -534,7 +534,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
 * @property {number|string}      [GameConfig.antialias=true]
 * @property {number|string}      [GameConfig.backgroundColor=0]             - Sets {@link Phaser.Stage#backgroundColor}.
 * @property {HTMLCanvasElement}  [GameConfig.canvas]                        - An existing canvas to display the game in.
-* @property {string}             [GameConfig.canvasId]                      - `id` attribute value to assign to the game canvas.
+* @property {string}             [GameConfig.canvasID]                      - `id` attribute value to assign to the game canvas.
 * @property {string}             [GameConfig.canvasStyle]                   - `style` attribute value to assign to the game canvas.
 * @property {boolean}            [GameConfig.clearBeforeRender=true]        - Sets {@link Phaser.Game#clearBeforeRender}.
 * @property {boolean}            [GameConfig.crisp=false]                   - Sets the canvas's `image-rendering` property to `pixelated` or `crisp-edges`. See {@link Phaser.Canvas.setImageRenderingCrisp}.


### PR DESCRIPTION
This PR changes documentation.

It turns out the documented `canvasId` property for `GameConfig` doesn't actually set an id attribute on the canvas. [Phaser is looking for a property named `canvasID` instead.](https://github.com/photonstorm/phaser-ce/blob/master/src/core/Game.js#L856)

This PR changes `canvasId` to `canvasID` in the docs for `GameConfig` to account for this. 
(You'll notice this PR doesn't include any changes to `docs/` - I figure those are generated on release and did not touch the grunt commands that make them. If you'd like me to also rebuild those docs as part of this PR, I certainly can!)