### PR TITLE
fix: dds compression rendering support

### DIFF
--- a/src/loader/LoaderParser.js
+++ b/src/loader/LoaderParser.js
@@ -394,6 +394,12 @@ Phaser.LoaderParser = {
                 ddsHeader.arraySize = uintArray[34];
                 ddsHeader.miscFlag = uintArray[35];
             }
+            else if(ddsHeader.formatFourCC === 'DXT5'){
+                ddsHeader.glExtensionFormat = 0x83F3;
+            }
+            else if(ddsHeader.formatFourCC === 'DXT3'){
+                ddsHeader.glExtensionFormat = 0x83F2;
+            }
         }
 
         return ddsHeader;


### PR DESCRIPTION
This PR

* is a bug fix (closes #562)

fullfill the function of LoaderParser.dds to initialize ddsHeader.glExtensionFormat
