### PR TITLE
Fixed TS definition for clear in RenderTexture

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### TypeScript definitions
 
 * Fixed TS definition for bitmapText in GameObjectFactory.
+* Fixed TS definition for clear in RenderTexture.
 
 ### Documentation
 
@@ -340,7 +341,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@rydash
+@rydash @tiagokeller
 
 ## Version 2.11.0 - 26 June 2018
 

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4457,6 +4457,7 @@ declare module Phaser {
         key: string;
         type: number;
 
+        clear(): void;
         render(displayObject: PIXI.DisplayObject, matrix?: Phaser.Matrix, clear?: boolean): void;
         renderXY(displayObject: PIXI.DisplayObject, x: number, y: number, clear?: boolean): void;
         renderRawXY(displayObject: PIXI.DisplayObject, x: number, y: number, clear?: boolean): void;


### PR DESCRIPTION
This PR
* changes TypeScript definitions

Describe the changes below:
Fixed TS definition for clear in RenderTexture.