### PR TITLE
Karlmerten/render texture fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ### Thanks
 
-@rydash @tiagokeller
+@rydash @tiagokeller @Mertank
 
 ## Version 2.11.0 - 26 June 2018
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 
 ## Unreleased
 
+Fixes an issue where if the WebGL renderer failed to initialize that RenderTexture's would still try to use it if no renderer was provided.
+
 ### TypeScript definitions
 
 * Fixed TS definition for bitmapText in GameObjectFactory.

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -890,6 +890,7 @@ Phaser.Game.prototype = {
             }
             catch (webGLRendererError)
             {
+                PIXI.defaultRenderer = null;
                 this.renderer = null;
                 this.multiTexture = false;
                 PIXI._enableMultiTextureToggle = false;


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* is a bug fix

Describe the changes below:

There was an issue where if WebGLRenderer failed to get created that PIXI.defaultRenderer was already set and RenderTextures that didn't get a renderer passed in would try to use the uninitialized WebGLRenderer to create themselves.