### PR TITLE
Fix the video volume's Typescript definitition.

### DIFF
--- a/typescript/phaser.comments.d.ts
+++ b/typescript/phaser.comments.d.ts
@@ -17693,7 +17693,7 @@ declare module Phaser {
         /**
         * Gets or sets the volume of the Video, a value between 0 and 1. The value given is clamped to the range 0 to 1.
         */
-        volume: boolean;
+        volume: number;
 
         /**
         * Gets or sets the playback rate of the Video. This is the speed at which the video is playing.


### PR DESCRIPTION
This PR 

* changes TypeScript definitions

Describe the changes below:

Fixed the video volume's typescript definition to be a number. Previously it was a boolean, which was incorrect.
