### PR TITLE
 Fixed BitmapData.shadow ignoring 0 blur or 0 offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,11 @@ Game now nulls a reference to itself from PIXI after destroy.
 ### Bug Fixes
 
 * Fixed a BitmapFont frame error when using trim frame in atlas.
+* Fixed BitmapData.shadow ignoring blur or x/y offset when set to 0
 
 ### Thanks
 
-@rydash @tiagokeller @Mertank @giniwren @josalmi, @B10215029
+@rydash @tiagokeller @Mertank @giniwren @josalmi, @B10215029, @Jazcash
 
 ## Version 2.11.0 - 26 June 2018
 

--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -1793,9 +1793,9 @@ Phaser.BitmapData.prototype = {
         else
         {
             ctx.shadowColor = color;
-            ctx.shadowBlur = blur || 5;
-            ctx.shadowOffsetX = x || 10;
-            ctx.shadowOffsetY = y || 10;
+            ctx.shadowBlur = (blur === 0) ? 0 : blur || 5;
+            ctx.shadowOffsetX = (x === 0) ? 0 : x || 10;
+            ctx.shadowOffsetY = (y === 0) ? 0 : y || 10;
         }
 
         return this;


### PR DESCRIPTION
Previously sending 0 would equate to a 'falsey' value and force defaults to be used instead, making it impossible to set a shadow with 0 blur or 0 xpos/ypos.

This PR (choose one or more, ✏️ delete others)

* is a bug fix

Please include a summary in [README.md: Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/README.md#unreleased) and thank yourself.
