### PR TITLE
Add Camera#centerX, Camera#centerY (Thanks @samme)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,10 +337,11 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Updates
 
 * BitmapText has a new property `letterSpacing` which accepts a positive or negative number to add / reduce spacing between characters
+* Camera now has new properties `centerX` and `centerY` to get the center of the camera's current viewport
 
 ### Thanks
 
-@wtravO, @rroylance
+@wtravO, @rroylance, @samme
 
 ## Version 2.11.1 - 2 October 2018
 

--- a/src/core/Camera.js
+++ b/src/core/Camera.js
@@ -1010,3 +1010,37 @@ Object.defineProperty(Phaser.Camera.prototype, 'fixedView', {
     }
 
 });
+
+/**
+ * The x position of the center of the Camera's viewport, relative to the top-left of the game canvas.
+ * @name Phaser.Camera#centerX
+ * @property {number} centerX
+ * @readonly
+ */
+Object.defineProperty(Phaser.Camera.prototype, 'centerX', {
+
+    get: function ()
+    {
+
+        return (this.x + (0.5 * this.width));
+
+    }
+
+});
+
+/**
+ * The y position of the center of the Camera's viewport, relative to the top-left of the game canvas.
+ * @name Phaser.Camera#centerY
+ * @property {number} centerY
+ * @readonly
+ */
+Object.defineProperty(Phaser.Camera.prototype, 'centerY', {
+
+    get: function ()
+    {
+
+        return (this.y + (0.5 * this.height));
+
+    }
+
+});


### PR DESCRIPTION
This PR
* changes documentation
* changes TypeScript definitions
* changes the public-facing API

Describe the changes below:
These are read-only properties representing the coordinates of the center of the viewport.

They're convenient for positioning Game Objects.