### PR TITLE
Creature json safety fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Written something cool in Phaser? Please tell us about it in the [forum][forum],
 ### Bug Fixes
 
 * Fixed issue causing BitmapFont to fail loading if a kerning value for a character that doesn't exist in the font is defined in the xml/json.
+* Fix for Creature runtime modifying the JSON object you give it from the Phaser.Cache making subsequent uses of that JSON not behave in various ways, depending on how you use the runtime (when having multiple Creature objects of the same character for example)
 
 ### Updates
 

--- a/src/gameobjects/Creature.js
+++ b/src/gameobjects/Creature.js
@@ -200,7 +200,7 @@ Phaser.Creature = function (game, x, y, key, mesh, animation, useFlatData)
         return;
     }
 
-    var meshData = game.cache.getJSON(mesh);
+    var meshData = game.cache.getJSON(mesh, true);
 
     /**
     * @property {Creature} _creature - The Creature instance.
@@ -906,7 +906,7 @@ Phaser.Creature.prototype.createAllAnimations = function (mesh)
         return;
     }
 
-    var meshData = this.game.cache.getJSON(mesh);
+    var meshData = this.game.cache.getJSON(mesh, true);
 
     this.manager.CreateAllAnimations(meshData);
 };
@@ -925,7 +925,7 @@ Phaser.Creature.prototype.setMetaData = function (meta)
 
     }
 
-    var metaJson = this.game.cache.getJSON(meta);
+    var metaJson = this.game.cache.getJSON(meta, true);
     var metaData = CreatureModuleUtils.BuildCreatureMetaData(metaJson);
 
     this._creature.SetMetaData(metaData);


### PR DESCRIPTION
This PR
* is a bug fix

Describe the changes below:
Simply uses the clone parameter of Phaser.Cache.getJSON to prevent the Creature runtime modifying the JSON object you give it from the Phaser.Cache making subsequent uses of that JSON not behave in various ways, depending on how you use the runtime (when having multiple Creature objects of the same character for example)