### PR TITLE
Video GameObject doesn't work on Firefox 62

### DIFF
--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -477,6 +477,10 @@ Phaser.Video.prototype = {
         {
             this.video.mozSrcObject = stream;
         }
+        else if (this.video.srcObject !== undefined)
+        {
+            this.video.srcObject = stream;
+        }
         else
         {
             this.video.src = (window.URL && window.URL.createObjectURL(stream)) || stream;
@@ -793,6 +797,11 @@ Phaser.Video.prototype = {
             if (this.video.mozSrcObject)
             {
                 this.video.mozSrcObject.stop();
+                this.video.src = null;
+            }
+            else if (this.video.srcObject)
+            {
+                this.video.srcObject.stop();
                 this.video.src = null;
             }
             else


### PR DESCRIPTION
`HTMLMediaElement.mozSrcObject` has been removed with Firefox 58 and `URL.createObjectURL()` no longer accepts a stream as argument with Firefox 62

References:

* https://www.fxsitecompat.com/en-CA/docs/2017/htmlmediaelement-mozsrcobject-has-been-removed/
* https://www.fxsitecompat.com/en-CA/docs/2018/url-createobjecturl-no-longer-accepts-mediastream-as-argument/
