### PR TITLE
Bugfix: Texture smoothing

### DIFF
--- a/src/gameobjects/components/Smoothed.js
+++ b/src/gameobjects/components/Smoothed.js
@@ -38,15 +38,19 @@ Phaser.Component.Smoothed.prototype = {
             {
                 if (this.texture)
                 {
-                    this.texture.baseTexture.scaleMode = 0;
-                    this.texture.baseTexture.dirty();
+                    if (this.texture.baseTexture.scaleMode != 0){
+                        this.texture.baseTexture.scaleMode = 0;
+                        this.texture.baseTexture.dirty();
+                    }
                 }
             }
             else
             if (this.texture)
             {
-                this.texture.baseTexture.scaleMode = 1;
-                this.texture.baseTexture.dirty();
+                if (this.texture.baseTexture.scaleMode != 1){
+                    this.texture.baseTexture.scaleMode = 1;
+                    this.texture.baseTexture.dirty();
+                }
             }
         }
 

--- a/src/gameobjects/components/Smoothed.js
+++ b/src/gameobjects/components/Smoothed.js
@@ -38,7 +38,7 @@ Phaser.Component.Smoothed.prototype = {
             {
                 if (this.texture)
                 {
-                    if (this.texture.baseTexture.scaleMode != 0){
+                    if (this.texture.baseTexture.scaleMode !== 0){
                         this.texture.baseTexture.scaleMode = 0;
                         this.texture.baseTexture.dirty();
                     }
@@ -47,7 +47,7 @@ Phaser.Component.Smoothed.prototype = {
             else
             if (this.texture)
             {
-                if (this.texture.baseTexture.scaleMode != 1){
+                if (this.texture.baseTexture.scaleMode !== 1){
                     this.texture.baseTexture.scaleMode = 1;
                     this.texture.baseTexture.dirty();
                 }


### PR DESCRIPTION
only mark texture as dirty when scaleMode differs from previous value

This PR (choose one or more, ✏️ delete others)
* is a bug fix 

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:
Commit 7ea0dd2 a fix for #432 but marks texture always as dirty. Even if the smoothed value doesn't change at all. This fix now checks if the previous value actually differs to current. If it does, it marks the texture as dirty. This fixes some performance regressions for our framework that the commit introduced.