### PR TITLE
Gamepad Unplug Error

### DIFF
--- a/src/input/SinglePad.js
+++ b/src/input/SinglePad.js
@@ -173,7 +173,7 @@ Phaser.SinglePad.prototype = {
     pollStatus: function ()
     {
 
-        if (!this.connected || !this.game.input.enabled || !this.game.input.gamepad.enabled || (this._rawPad && this._rawPad.timestamp && (this._rawPad.timestamp === this._prevTimestamp)))
+        if (!this.connected || !this.game.input.enabled || !this.game.input.gamepad.enabled || !this._rawPad || this._rawPad.timestamp && this._rawPad.timestamp === this._prevTimestamp)
         {
             return;
         }


### PR DESCRIPTION
* is a bug fix 

Describe the changes below:
When Gamepad got unplugged it sometimes got an buttons of undefined Error. In January we fixed the timestamp issue... but that hasn't solved it completely. I now ran the game with this proposed change for quite a while and no Error on unplug happened so far.