### PR TITLE
Fix for webGL performance on mobile devices and other issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Bug Fixes
 
+* Fix for WebGL being slower than Cavas on iOS and Android (#356)
 * Fixed Point.fuzzyEquals and Point.fuzzyEqualsXY (#634).
 
 ### Thanks
 
-@Cerlancism, @samme
+@jamieallen1234, @Cerlancism, @samme
 
 ## Version 2.13.2 - 22 May 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* Fix for WebGL being slower than Cavas on iOS and Android (#356)
+* Fix for WebGL being slower than Canvas on iOS and Android (#356)
 * Fixed Point.fuzzyEquals and Point.fuzzyEqualsXY (#634).
 
 ### Thanks

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -907,13 +907,15 @@ Phaser.Game.prototype = {
 
         if (!this.renderer)
         {
-            this.renderer = new PIXI.CanvasRenderer(this, this.config);
-            this.context = this.renderer.context;
-
             if (this.renderType === Phaser.AUTO)
             {
                 this.renderType = Phaser.CANVAS;
+
+                this.canvas = Phaser.Canvas.create(this, this.width, this.height, this.config.canvasID, true);
             }
+
+            this.renderer = new PIXI.CanvasRenderer(this, this.config);
+            this.context = this.renderer.context;
         }
 
         if (this.device.cocoonJS)
@@ -1086,6 +1088,12 @@ Phaser.Game.prototype = {
             {
                 this.updateRender(this._deltaTime / slowStep);
             }
+        }
+
+        if (this.renderer.type === Phaser.WEBGL)
+        {
+            // flush gl to prevent flickering on some android devices
+            this.renderer.gl.flush();
         }
 
     },

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -907,15 +907,13 @@ Phaser.Game.prototype = {
 
         if (!this.renderer)
         {
+            this.renderer = new PIXI.CanvasRenderer(this, this.config);
+            this.context = this.renderer.context;
+
             if (this.renderType === Phaser.AUTO)
             {
                 this.renderType = Phaser.CANVAS;
-
-                this.canvas = Phaser.Canvas.create(this, this.width, this.height, this.config.canvasID, true);
             }
-
-            this.renderer = new PIXI.CanvasRenderer(this, this.config);
-            this.context = this.renderer.context;
         }
 
         if (this.device.cocoonJS)

--- a/src/gameobjects/components/LoadTexture.js
+++ b/src/gameobjects/components/LoadTexture.js
@@ -71,7 +71,7 @@ Phaser.Component.LoadTexture.prototype = {
         var cache = this.game.cache;
 
         var setFrame = true;
-        var smoothed = !this.texture.baseTexture.scaleMode;
+        var smoothed = this.texture.baseTexture.scaleMode === PIXI.scaleModes.LINEAR;
 
         if (Phaser.RenderTexture && key instanceof Phaser.RenderTexture)
         {
@@ -112,6 +112,8 @@ Phaser.Component.LoadTexture.prototype = {
         }
         else if (key instanceof PIXI.Texture)
         {
+            smoothed = key.baseTexture.scaleMode === PIXI.scaleModes.LINEAR;
+
             this.setTexture(key);
         }
         else

--- a/src/gameobjects/components/Smoothed.js
+++ b/src/gameobjects/components/Smoothed.js
@@ -38,16 +38,17 @@ Phaser.Component.Smoothed.prototype = {
             {
                 if (this.texture)
                 {
-                    if (this.texture.baseTexture.scaleMode !== 0){
+                    if (this.texture.baseTexture.scaleMode !== 0)
+                    {
                         this.texture.baseTexture.scaleMode = 0;
                         this.texture.baseTexture.dirty();
                     }
                 }
             }
-            else
-            if (this.texture)
+            else if (this.texture)
             {
-                if (this.texture.baseTexture.scaleMode !== 1){
+                if (this.texture.baseTexture.scaleMode !== 1)
+                {
                     this.texture.baseTexture.scaleMode = 1;
                     this.texture.baseTexture.dirty();
                 }

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -534,7 +534,7 @@ PIXI.WebGLRenderer.prototype.updateCompressedTexture = function (texture)
  */
 PIXI.WebGLRenderer.prototype.updateTexture = function (texture)
 {
-    if (!texture.hasLoaded)
+    if (!texture.hasLoaded || !texture.source)
     {
         return false;
     }

--- a/src/pixi/renderers/webgl/utils/WebGLFastSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLFastSpriteBatch.js
@@ -198,6 +198,13 @@ PIXI.WebGLFastSpriteBatch.prototype.render = function (spriteBatch)
         this.renderSession.blendModeManager.setBlendMode(sprite.blendMode);
     }
 
+    var textureIndex = this.currentBaseTexture.textureIndex;
+    var gl = this.gl;
+    
+    gl.activeTexture(gl.TEXTURE0 + textureIndex);
+    gl.bindTexture(gl.TEXTURE_2D, this.currentBaseTexture._glTextures[gl.id]);
+    PIXI.WebGLRenderer.textureArray[textureIndex] = this.currentBaseTexture;
+
     for(var i = 0,j = children.length; i < j; i++)
     {
         this.renderSprite(children[i]);

--- a/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
@@ -253,15 +253,6 @@ PIXI.WebGLSpriteBatch.prototype.end = function ()
 PIXI.WebGLSpriteBatch.prototype.render = function (sprite, matrix)
 {
     var texture = sprite.texture;
-    var baseTexture = texture.baseTexture;
-    var gl = this.gl;
-    if (PIXI.WebGLRenderer.textureArray[baseTexture.textureIndex] != baseTexture) // eslint-disable-line eqeqeq
-    {
-        this.flush();
-        gl.activeTexture(gl.TEXTURE0 + baseTexture.textureIndex);
-        gl.bindTexture(gl.TEXTURE_2D, baseTexture._glTextures[gl.id]);
-        PIXI.WebGLRenderer.textureArray[baseTexture.textureIndex] = baseTexture;
-    }
 
     //  They provided an alternative rendering matrix, so use it
     var wt = sprite.worldTransform;
@@ -434,16 +425,7 @@ PIXI.WebGLSpriteBatch.prototype.render = function (sprite, matrix)
 PIXI.WebGLSpriteBatch.prototype.renderTilingSprite = function (sprite)
 {
     var texture = sprite.tilingTexture;
-    var baseTexture = texture.baseTexture;
-    var gl = this.gl;
     var textureIndex = sprite.texture.baseTexture.textureIndex;
-    if (PIXI.WebGLRenderer.textureArray[textureIndex] != baseTexture) // eslint-disable-line eqeqeq
-    {
-        this.flush();
-        gl.activeTexture(gl.TEXTURE0 + textureIndex);
-        gl.bindTexture(gl.TEXTURE_2D, baseTexture._glTextures[gl.id]);
-        PIXI.WebGLRenderer.textureArray[textureIndex] = baseTexture;
-    }
 
     // check texture..
     if (this.currentBatchSize >= this.size)
@@ -675,7 +657,7 @@ PIXI.WebGLSpriteBatch.prototype.flush = function ()
         }
 
         //
-        if (/* (currentBaseTexture != nextTexture && !skip) || */
+        if ((currentBaseTexture !== nextTexture && !skip) ||
             blendSwap ||
             shaderSwap)
         {


### PR DESCRIPTION
This PR is a is a bug fix (closes #356)

Describe the changes below:

- Fix for webGL making excessive gl calls, which was negatively impacting the frame-rate of low-end machines and mobile devices. (broken since original fork of phaser 2)
- Fix for smoothed setting on textures not being respected.
- Fix for updateTexture happening on textures that hadn't loaded their source yet.
- Fix for flickering issue on some android devices.
- Fix eslint errors.