### PR TITLE
Add powerPreference hint to PIXI WebGLRenderer context options

### DIFF
--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -470,6 +470,11 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
     this.dropFrames = false;
 
     /**
+    * @property {string} powerPreference - When the WebGL renderer is used, hint to the browser which GPU to use.
+    */
+    this.powerPreference = 'default';
+
+    /**
     * @property {number} _nextNotification - The soonest game.time.time value that the next fpsProblemNotifier can be dispatched.
     * @private
     */
@@ -555,6 +560,7 @@ Phaser.Game = function (width, height, renderer, parent, state, transparent, ant
 * @property {string|HTMLElement} [GameConfig.parent='']                     - The DOM element into which this games canvas will be injected.
 * @property {object}             [GameConfig.physicsConfig]
 * @property {boolean}            [GameConfig.pointerLock=true]              - Starts the {@link Phaser.PointerLock Pointer Lock} handler, if supported by the device.
+* @property {string}             [GameConfig.powerPreference='default']     - Sets the WebGL renderer's powerPreference when the WebGL renderer is used.
 * @property {boolean}            [GameConfig.preserveDrawingBuffer=false]   - Whether or not the contents of the stencil buffer is retained after rendering.
 * @property {number}             [GameConfig.renderer=Phaser.AUTO]
 * @property {number}             [GameConfig.resolution=1]                  - The resolution of your game, as a ratio of canvas pixels to game pixels.
@@ -638,6 +644,11 @@ Phaser.Game.prototype = {
         if (config.preserveDrawingBuffer !== undefined)
         {
             this.preserveDrawingBuffer = config.preserveDrawingBuffer;
+        }
+
+        if (config.powerPreference !== undefined)
+        {
+            this.powerPreference = config.powerPreference;
         }
 
         if (config.physicsConfig)

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -83,6 +83,15 @@ PIXI.WebGLRenderer = function (game, config)
     this.clearBeforeRender = game.clearBeforeRender;
 
     /**
+     * This sets the WebGL "powerPreference" on the WebGL context, a hint to the browser to use a high-performance GPU.
+     *
+     * @property powerPreference
+     * @type string
+     * @default
+     */
+    this.powerPreference = game.powerPreference;
+
+    /**
      * The width of the canvas view
      *
      * @property width
@@ -117,7 +126,8 @@ PIXI.WebGLRenderer = function (game, config)
         failIfMajorPerformanceCaveat: config.failIfMajorPerformanceCaveat,
         premultipliedAlpha: this.transparent && this.transparent !== 'notMultiplied',
         stencil: true,
-        preserveDrawingBuffer: this.preserveDrawingBuffer
+        preserveDrawingBuffer: this.preserveDrawingBuffer,
+        powerPreference: game.powerPreference
     };
 
     /**

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -1494,6 +1494,7 @@ declare module Phaser {
         parent?: HTMLElement | string;
         physicsConfig?: any;
         pointerLock?: boolean;
+        powerPreference?: "default" | "low-power" | "high-performance";
         preserveDrawingBuffer?: boolean;
         renderer?: number;
         resolution?: number;
@@ -1565,6 +1566,7 @@ declare module Phaser {
         physics: Phaser.Physics;
         physicsConfig: any;
         plugins: PluginManager;
+        powerPreference: "default" | "low-power" | "high-performance";
         preserveDrawingBuffer: Boolean;
         raf: Phaser.RequestAnimationFrame;
         renderer: PIXI.CanvasRenderer | PIXI.WebGLRenderer;


### PR DESCRIPTION
This PR
* changes the public-facing API

As the changelog doesn't seem to have an "unreleased" section, I didn't add to this. This is my first pull request to this project, so I suspect it may need some massaging / discussion; I was going to file an issue but decided it is probably best to try to make an effort to fix the problem instead of complain.

**Describe the changes below:**

This adds support for `powerPreference` hinting to the PIXI WebGLRenderer's context options, per the spec at https://www.khronos.org/registry/webgl/specs/latest/1.0/. In situations where a high-performance GPU is available (e.g. laptops with discrete GPUs) this offers the ability to hint to the browser that you would like to use one GPU or the other. Note that this may cause greater power consumption.

Per the WebGL spec, "Applications that request high-performance should test and maintain robust context loss handling, as User Agents are very likely to decide to lose background high-performance contexts." Phaser appears to handle context loss, but I am admittedly new to this codebase and believe that the community should probably test this.

Phaser 3.x has this setting in game config (/src/core/Config.js), and WebGLRenderer.js L581 instantiates the context in a similar fashion to this pull request. This is an attempt to backport the functionality to Phaser CE.