### PR TITLE
Bugfix/audio tag loop fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@
 
 ### Bug Fixes
 
-- A sprite's [tintedTexture](https://photonstorm.github.io/phaser-ce/PIXI.Sprite.html#tintedTexture) canvas is now returned to the Canvas Pool when the sprite is destroyed (#651).
+* Fixed glitching sound playing when using looping audio-sprites with audio-tag (#653).
+* A sprite's [tintedTexture](https://photonstorm.github.io/phaser-ce/PIXI.Sprite.html#tintedTexture) canvas is now returned to the Canvas Pool when the sprite is destroyed (#651).
 
 ### Thanks
 
-@rarecoil, @samme, @taoabc
+@rarecoil, @samme, @taoabc, @dhashvir
 
 ## Version 2.13.3 - 17 Sep 2019
 

--- a/src/sound/Sound.js
+++ b/src/sound/Sound.js
@@ -570,6 +570,7 @@ Phaser.Sound.prototype = {
                     this.isPlaying = false;
 
                     this.play(this.currentMarker, 0, this.volume, true, true);
+                    this._pendingStart = false; // Need to set to false for looping sounds otherwise it keeps resetting.
                 }
                 else
                 {


### PR DESCRIPTION
This PR
* is a bug fix (closes #653)

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:
Fixes glitching sound when using looping audio-sprites with audio-tag. 