### PR TITLE
crossorigin attribute on video

### DIFF
--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -550,9 +550,10 @@ Phaser.Video.prototype = {
      * @method Phaser.Video#createVideoFromURL
      * @param {string} url - The URL of the video.
      * @param {boolean} [autoplay=false] - Automatically start the video?
+     * @param {string} crossOrigin - The crossorigin parameter provides support for CORS
      * @return {Phaser.Video} This Video object for method chaining.
      */
-    createVideoFromURL: function (url, autoplay)
+    createVideoFromURL: function (url, autoplay, crossOrigin)
     {
         if (autoplay === undefined) { autoplay = false; }
 
@@ -568,6 +569,11 @@ Phaser.Video.prototype = {
         if (autoplay)
         {
             this.video.setAttribute('autoplay', 'autoplay');
+        }
+
+        if (crossOrigin !== undefined)
+        {
+            this.video.crossOrigin = crossOrigin;
         }
 
         this.video.setAttribute('playsinline', 'playsinline');

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -3137,7 +3137,7 @@ declare module Phaser {
         addToWorld(x?: number, y?: number, anchorX?: number, anchorY?: Number, scaleX?: number, scaleY?: number): Phaser.Image;
         createVideoFromBlob(blob: Blob): Phaser.Video;
         startMediaStream(captureAudio?: boolean, width?: number, height?: number): Phaser.Video;
-        createVideoFromURL(url: string, autoplay?: boolean): Phaser.Video;
+        createVideoFromURL(url: string, autoplay?: boolean, crossOrigin?: string): Phaser.Video;
         changeSource(src: string, autoplay?: boolean): Phaser.Video;
         connectToMediaStram(video: any, stream: any): Phaser.Video;
         destroy(): void;


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* changes documentation
* changes TypeScript definitions
* changes the public-facing API

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:

Some storage services (i.e. S3) won't send CORS headers if the CORS attribute is not included in the request. The browser will refuse to load the video (createVideoFromURL) from S3.

https://docs.aws.amazon.com/AmazonS3/latest/dev/cors-troubleshooting.html (2.a)

"If the header is missing, Amazon S3 doesn't treat the request as a cross-origin request, and doesn't send CORS response headers in the response." 

More info:

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#attr-crossorigin