### PR TITLE
getUserMedia constraints

### DIFF
--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -364,16 +364,19 @@ Phaser.Video.prototype = {
      * You can listen for this with the onChangeSource signal.
      *
      * @method Phaser.Video#startMediaStream
-     * @param {boolean} [captureAudio=false] - Controls if audio should be captured along with video in the video stream.
+     * @param {boolean|MediaTrackConstraints} [captureAudio=false] - Controls if audio should be captured along with video in the video stream.
      * @param {integer} [width] - The width is used to create the video stream. If not provided the video width will be set to the width of the webcam input source.
      * @param {integer} [height] - The height is used to create the video stream. If not provided the video height will be set to the height of the webcam input source.
+     * @param {boolean|MediaTrackConstraints} [captureVideo] - Constraints and settings used to create the video stream.
      * @return {Phaser.Video} This Video object for method chaining or false if the device doesn't support getUserMedia.
      */
-    startMediaStream: function (captureAudio, width, height)
+    startMediaStream: function (captureAudio, width, height, captureVideo)
     {
+
         if (captureAudio === undefined) { captureAudio = false; }
         if (width === undefined) { width = null; }
         if (height === undefined) { height = null; }
+        if (captureVideo === undefined) { captureVideo = true; }
 
         if (!this.game.device.getUserMedia)
         {
@@ -413,17 +416,24 @@ Phaser.Video.prototype = {
 
         this._timeOutID = window.setTimeout(this.getUserMediaTimeout.bind(this), this.timeout);
 
-        try
+        if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia)
         {
-            navigator.getUserMedia(
-                { audio: captureAudio, video: true },
-                this.getUserMediaSuccess.bind(this),
-                this.getUserMediaError.bind(this)
-            );
+            navigator.mediaDevices.getUserMedia({ audio: captureAudio, video: captureVideo })
+                .then(this.getUserMediaSuccess.bind(this))
+                .catch(this.getUserMediaError.bind(this));
         }
-        catch (error)
+        else
         {
-            this.getUserMediaError(error);
+            try
+            {
+                    navigator.getUserMedia({ audio: captureAudio, video: captureVideo },
+                        this.getUserMediaSuccess.bind(this),
+                        this.getUserMediaError.bind(this));
+            }
+            catch (error)
+            {
+                this.getUserMediaError(error);
+            }
         }
 
         return this;

--- a/src/gameobjects/Video.js
+++ b/src/gameobjects/Video.js
@@ -372,7 +372,6 @@ Phaser.Video.prototype = {
      */
     startMediaStream: function (captureAudio, width, height, captureVideo)
     {
-
         if (captureAudio === undefined) { captureAudio = false; }
         if (width === undefined) { width = null; }
         if (height === undefined) { height = null; }
@@ -426,9 +425,9 @@ Phaser.Video.prototype = {
         {
             try
             {
-                    navigator.getUserMedia({ audio: captureAudio, video: captureVideo },
-                        this.getUserMediaSuccess.bind(this),
-                        this.getUserMediaError.bind(this));
+                navigator.getUserMedia({ audio: captureAudio, video: captureVideo },
+                    this.getUserMediaSuccess.bind(this),
+                    this.getUserMediaError.bind(this));
             }
             catch (error)
             {

--- a/typescript/phaser.d.ts
+++ b/typescript/phaser.d.ts
@@ -4,6 +4,8 @@
 // Type definitions for Phaser CE
 // Project: https://github.com/photonstorm/phaser-ce
 
+interface MediaTrackConstraints {}
+
 declare module "phaser-ce" {
     export = Phaser;
 }
@@ -3136,7 +3138,7 @@ declare module Phaser {
         add(object: Phaser.Sprite | Phaser.Sprite[] | Phaser.Image | Phaser.Image[]): Phaser.Video;
         addToWorld(x?: number, y?: number, anchorX?: number, anchorY?: Number, scaleX?: number, scaleY?: number): Phaser.Image;
         createVideoFromBlob(blob: Blob): Phaser.Video;
-        startMediaStream(captureAudio?: boolean, width?: number, height?: number): Phaser.Video;
+        startMediaStream(captureAudio?: boolean | MediaTrackConstraints, width?: number, height?: number, captureVideo?: MediaTrackConstraints): Phaser.Video;
         createVideoFromURL(url: string, autoplay?: boolean): Phaser.Video;
         changeSource(src: string, autoplay?: boolean): Phaser.Video;
         connectToMediaStram(video: any, stream: any): Phaser.Video;


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* changes documentation
* changes TypeScript definitions
* changes the public-facing API

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:

This patch allows to pass constraint arguments to getUserMedia() via startMediaStream():

```
video.startMediaStream({
            sampleSize: 8,
            echoCancellation: true
        }, null, null, {
            facingMode: { ideal: 'user' },
            width: 640,
            height: 480
        });
```

https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints