### PR TITLE
Respect tiled properties as an array

### DIFF
--- a/src/tilemap/Tilemap.js
+++ b/src/tilemap/Tilemap.js
@@ -461,9 +461,22 @@ Phaser.Tilemap.prototype = {
 
                 group.add(sprite);
 
-                for (var property in obj.properties)
+                //  Set properties the class may have, or setData those it doesn't
+                if (Array.isArray(obj.properties))
                 {
-                    group.set(sprite, property, obj.properties[property], false, false, 0, true);
+                    // Tiled objects custom properties format
+                    obj.properties.forEach(function (propData)
+                    {
+                        var key = propData.name;
+                        sprite[key] = propData.value;
+                    });
+                }
+                else
+                {
+                    for (var property in obj.properties)
+                    {
+                        group.set(sprite, property, obj.properties[property], false, false, 0, true);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR

* changes documentation

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:

Adaptation of:
https://github.com/photonstorm/phaser/commit/fea65988f41e3b66461a4ee8698af9457dac6286

Tiled objects have properties as an array of objects like:

  { name: ..., type: ..., value: ...}

Update the parser to load these using the name/value properties instead
of just treating it as an array and loading properties named '0', '1',
etc.

sprite.setData does not exist in PhaserCE. therefore the property is set directly on the sprite.
