### PR TITLE
Fix from 2.13.3 for 'excessive webgl calls' was removed in 2.15.0 to …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## Unreleased
+
+#### Added
+- re-enabled fix from 13.3.3 'Fixed webGL making excessive calls, which was negatively impacting the frame-rate of low-end', but only when multitexture batching is disabled.
+
+### Thanks
+
+@drfrankius
+
 ## Version 2.17.0 - 16 March 2021
 
 ### API Changes


### PR DESCRIPTION
…fix multi-texture batching. This allows the fix from 2.13.3 to be enabled when multiTexture: false is set

is a bug fix (closes #681)

Please include a summary in [Change Log: Unreleased](https://github.com/photonstorm/phaser-ce/blob/master/CHANGELOG.md) and thank yourself.

Describe the changes below:

Phaser CE 13.3.3 had a fix for 'Fixed webGL making excessive calls, which was negatively impacting the frame-rate of low-end machines and mobile devices (#356, #641).'. This fix boosted WEB-GL performance, but broke batching so was reverted in 2.15.0. This PR reenables that fix, but only when multiTexture: false is set in the game config. So multitexture batching should still work, and no excessive calls to bind / flush() should be made in the WebGLSpriteBatch when it is disabled.
