### PR TITLE
TilemapLayer: fix getRayCastTile implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+### Bug Fixes
+
+- [TilemapLayer#getRayCastTiles()](https://photonstorm.github.io/phaser-ce/Phaser.TilemapLayer.html#getRayCastTiles) was less efficient and behaved incorrectly for horizontal or vertical rays.
+
+### Thanks
+
+@noocsharp
+
 ## Version 2.19.0 - 23 August 2021
 
 ### API Changes

--- a/src/tilemap/TilemapLayer.js
+++ b/src/tilemap/TilemapLayer.js
@@ -581,29 +581,18 @@ Phaser.TilemapLayer.prototype.getRayCastTiles = function (line, stepRate, collid
     if (collides === undefined) { collides = false; }
     if (interestingFace === undefined) { interestingFace = false; }
 
-    //  First get all tiles that touch the bounds of the line
-    var tiles = this.getTiles(line.x, line.y, line.width, line.height, collides, interestingFace);
-
-    if (tiles.length === 0)
-    {
-        return [];
-    }
-
-    //  Now we only want the tiles that intersect with the points on this line
+    // Fetch coordinates to check
     var coords = line.coordinatesOnLine(stepRate);
     var results = [];
 
-    for (var i = 0; i < tiles.length; i++)
+    var point = {};
+    for (var t = 0; t < coords.length; t++)
     {
-        for (var t = 0; t < coords.length; t++)
+        this.getTileXY(coords[t][0], coords[t][1], point);
+        var tile = this.layer.data[point.y][point.x];
+        if (tile.index !== -1)
         {
-            var tile = tiles[i];
-            var coord = coords[t];
-            if (tile.containsPoint(coord[0], coord[1]))
-            {
-                results.push(tile);
-                break;
-            }
+            results.push(tile);
         }
     }
 


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* is a bug fix

Previously, getRayCastTile relied on getTiles, which retrieves
a list of tiles in some rectangle. Not only was this inefficient,
but it would cause getRayCastTile to sometimes return an empty
array when there were tiles in the ray. Specifically, this bug
could be triggered by calling getRayCastTile on a horizontal
or vertical line. Since this is converted to a zero width or height,
getTiles would return an empty array because `th = 0` or `tw = 0` in the
for statements:

    for (var wy = ty; wy < ty + th; wy++)

and

    for (var wx = tx; wx < tx + tw; wx++)

meaning these loops would not even start. This behavior makes sense
for the getTiles function, but does not for getRayCastTiles. Instead,
we get an array of coordinates on the line to check, and simply check
if a tile is present at these coordinates.
