### PR TITLE
Text: don't assign _testString from style parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - [TilemapLayer#getRayCastTiles()](https://photonstorm.github.io/phaser-ce/Phaser.TilemapLayer.html#getRayCastTiles) was less efficient and behaved incorrectly for horizontal or vertical rays.
+- [Text](https://photonstorm.github.io/phaser-ce/Phaser.Text.html#Text) no longer errors when missing a `style` parameter.
 
 ### Thanks
 

--- a/src/gameobjects/Text.js
+++ b/src/gameobjects/Text.js
@@ -159,7 +159,7 @@ Phaser.Text = function (game, x, y, text, style)
      * @property {string} _testString
      * @private
      */
-    this._testString = style.testString || '|MÂÉQfjq_';
+    this._testString = '|MÂÉQfjq_';
 
     /**
      * @property {number} _res - Internal canvas resolution var.


### PR DESCRIPTION
This PR (choose one or more, ✏️ delete others)

* is a bug fix (closes #XXX)

style._testString is accessed without checking whether style is
defined, which will result in an error if style is undefined.

This is a bug because style is an optional parameter.
