### PR TITLE
Pixi.WebGLSpriteBatch: bind to textureIndex only if it's defined

### DIFF
--- a/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
+++ b/src/pixi/renderers/webgl/utils/WebGLSpriteBatch.js
@@ -637,7 +637,10 @@ PIXI.WebGLSpriteBatch.prototype.flush = function ()
         gl.vertexAttribPointer(shader.colorAttribute, 4, gl.UNSIGNED_BYTE, true, stride, 16);
 
         // Texture index
-        gl.vertexAttribPointer(shader.aTextureIndex, 1, gl.FLOAT, false, stride, 20);
+        if (PIXI._enableMultiTextureToggle)
+        {
+            gl.vertexAttribPointer(shader.aTextureIndex, 1, gl.FLOAT, false, stride, 20);
+        }
     }
 
     // upload the verts to the buffer


### PR DESCRIPTION
This PR
* is a bug fix

textureIndex is only defined if MultiTexture is enabled, so WebGL
gives some warnings when it isn't, as shader.aTextureIndex is -1.