### PR TITLE
fix Phaser.Point.multiplyAdd

### DIFF
--- a/src/geom/Point.js
+++ b/src/geom/Point.js
@@ -747,7 +747,7 @@ Phaser.Point.multiplyAdd = function (a, b, s, out)
 {
     if (out === undefined) { out = new Phaser.Point(); }
 
-    return out.setTo(a.x + b.x * s, a.y + b.y * s);
+    return out.setTo((a.x + b.x) * s, (a.y + b.y) * s);
 };
 
 /**


### PR DESCRIPTION
fix Phaser.Point.multiplyAdd: so now it sums points and multiplies result. Earlier it multiplied only second point.
