### PR TITLE
fix bug in Phaser.Rope

### DIFF
--- a/src/gameobjects/Rope.js
+++ b/src/gameobjects/Rope.js
@@ -459,6 +459,11 @@ Phaser.Rope.prototype._renderStrip = function (renderSession)
  */
 Phaser.Rope.prototype._renderCanvas = function (renderSession)
 {
+    if (!this.visible || this.alpha <= 0)
+    {
+        return;
+    }
+    
     var context = renderSession.context;
 
     var transform = this.worldTransform;


### PR DESCRIPTION
fix bug in Phaser.Rope: now if visibility is false, it won't render
